### PR TITLE
Add Qiskit Adapter Integration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,3 +20,6 @@ datasets/
 # Secrets
 
 .env
+
+# System files
+.DS_Store

--- a/README.md
+++ b/README.md
@@ -49,25 +49,29 @@ list_of_benchmarks = BenchmarkManager.get_available_benchmarks("HW")
 
 config = {
     "benchmark_type": "HW",
-    "benchmark_name": "RB",
-    "interface": "pennylane",
-    "backend": "QLM",
+    "benchmark_name": "randomized_benchmarking",
+    "interface": "qiskit",
+    "backend": "QExa20",
     "integrator": "MQSS",
     "credentials": {
         "mqss_token": "<TOKEN>"
     },
     "wires": 2,
+    "shots": 200,
     "params": {}
 }
 
 benchmark_manager = BenchmarkManager(config)
 benchmark_manager.dispatch()
 ```
+### Supported interfaces
+- Qiskit Adapter (config value `qiskit`)
+- Pennylane Adapter (config value `pennylane`)
+
 A complete list of configuration options will be listed and constantly updated for the upcoming releases
 
 ## 🛠️ Upcoming Features
 - Integration of the [Toolchain Project]([https://pages.github.com/](https://gitlab.lrz.de/qcbm/benchmark-comparison)) to the Suite for Simulator Benchmarks
-- Connecting the Qiskit Adapter as an alternative interface
 - Improving the benchmark set for all types of benchmarks
 ## Contributing
 

--- a/src/adapters/adapter_factory.py
+++ b/src/adapters/adapter_factory.py
@@ -1,6 +1,5 @@
 from .pennylane_adapter import PennyLaneAdapter
-
-# from .qiskit_adapter import Qiskitadapter
+from .qiskit_adapter import QiskitAdapter
 
 
 def get_adapter(config):
@@ -8,7 +7,6 @@ def get_adapter(config):
     if interface == "pennylane":
         return PennyLaneAdapter(config)
     elif interface == "qiskit":
-        raise NotImplementedError("Qiskit Adapter not implemented yet")
-        # return QiskitAdapter(config)
+        return QiskitAdapter(config)
     else:
         raise ValueError(f"Unsupported interface: {interface}")

--- a/src/adapters/config.py
+++ b/src/adapters/config.py
@@ -11,4 +11,4 @@ MQSS_TOKEN = os.getenv("MQSS_TOKEN", "")
 MQSS_PORT = os.getenv("MQSS_PORT", "4000")
 MQSS_URL = os.getenv("MQSS_URL", "https://portal.quantum.lrz.de")
 MQSS_URL = f"{MQSS_URL}:{MQSS_PORT}"
-MQSS_BACKENDS = os.getenv("MQSS_BACKENDS", "QExa20")
+MQSS_BACKEND = os.getenv("MQSS_BACKEND", "QExa20")

--- a/src/adapters/pennylane_adapter.py
+++ b/src/adapters/pennylane_adapter.py
@@ -1,18 +1,28 @@
 from mqss.pennylane_adapter.device import MQSSPennylaneDevice
 from src.adapters.mqss_adapter import MQSSAdapter
-from src.adapters.config import MQSS_TOKEN
+from src.adapters.config import MQSS_TOKEN, MQSS_BACKEND
 
 
 class PennyLaneAdapter(MQSSAdapter):
     def __init__(self, config):
         super().__init__(config)
+
+        if not isinstance(config, dict):
+            raise TypeError("config must be a dict")
+        backend_name = str(config.get("backend", "") or MQSS_BACKEND).strip()
+        if not backend_name:
+            raise ValueError("Missing required config: backend or MQSS_BACKEND")
+        credentials = config.get("credentials") or {}
+        token = (credentials.get("mqss_token") if isinstance(credentials, dict) else None) or MQSS_TOKEN
+        if not token:
+            raise ValueError("Missing required config: credentials.mqss_token or MQSS_TOKEN")
+        shots = int(config["shots"]) if config.get("shots") is not None else None
+        
         self.device = MQSSPennylaneDevice(
-            # wires=config["wires"],
-            # token=config["credentials"]["mqss_token"],
-            # backends=[config["backend"]],
-            wires=2,
-            token=MQSS_TOKEN,
-            backends="QExa20",
+            wires=2, #TODO: use wires=config["wires"] later
+            token=token,
+            shots=shots,
+            backends=backend_name,
         )
 
     def run_circuit(self, circuit, params=None):
@@ -25,6 +35,7 @@ class PennyLaneAdapter(MQSSAdapter):
         Returns:
             _type_: _description_
         """
+        print("Running the circuit ...")  # print for debugging. TODO: later we can define a verbose mode
         qnode = circuit(self.device)
         if params is not None:
             return qnode(*params)

--- a/src/adapters/qiskit_adapter.py
+++ b/src/adapters/qiskit_adapter.py
@@ -1,6 +1,6 @@
 from src.adapters.mqss_adapter import MQSSAdapter
 from mqss.qiskit_adapter import MQSSQiskitAdapter
-from src.adapters.config import MQSS_TOKEN
+from src.adapters.config import MQSS_TOKEN, MQSS_BACKEND
 
 
 class QiskitAdapter(MQSSAdapter):
@@ -10,13 +10,13 @@ class QiskitAdapter(MQSSAdapter):
 
         if not isinstance(config, dict):
             raise TypeError("config must be a dict")
-        backend_name = str(config.get("backend", "")).strip()
+        backend_name = str(config.get("backend", "") or MQSS_BACKEND).strip()
         credentials = config.get("credentials") or {}
         token = (credentials.get("mqss_token") if isinstance(credentials, dict) else None) or MQSS_TOKEN
         if not token:
             raise ValueError("Missing required config: credentials.mqss_token or MQSS_TOKEN")
         if not backend_name:
-            raise ValueError("Missing required config: backend")
+            raise ValueError("Missing required config: backend or MQSS_BACKEND")
         self.adapter = MQSSQiskitAdapter(token=token)
         self.backend = self.adapter.get_backend(backend_name)
         self.shots = int(config["shots"]) if config.get("shots") is not None else None

--- a/src/adapters/qiskit_adapter.py
+++ b/src/adapters/qiskit_adapter.py
@@ -1,0 +1,46 @@
+from src.adapters.mqss_adapter import MQSSAdapter
+from mqss.qiskit_adapter import MQSSQiskitAdapter
+from src.adapters.config import MQSS_TOKEN
+
+
+class QiskitAdapter(MQSSAdapter):
+
+    def __init__(self, config):
+        super().__init__(config)
+
+        if not isinstance(config, dict):
+            raise TypeError("config must be a dict")
+        backend_name = str(config.get("backend", "")).strip()
+        credentials = config.get("credentials") or {}
+        token = (credentials.get("mqss_token") if isinstance(credentials, dict) else None) or MQSS_TOKEN
+        if not token:
+            raise ValueError("Missing required config: credentials.mqss_token or MQSS_TOKEN")
+        if not backend_name:
+            raise ValueError("Missing required config: backend")
+        self.adapter = MQSSQiskitAdapter(token=token)
+        self.backend = self.adapter.get_backend(backend_name)
+        self.shots = int(config["shots"]) if config.get("shots") is not None else None
+        #TODO: consider using config["wires"], which is number of qubits
+
+    def run_circuit(self, circuit, params=None):
+        """Given a Qiskit circuit, run it using the QiskitAdapter
+
+        Args:
+            circuit (callable): A builder function returning a `QuantumCircuit`.
+            params (float, optional): Parameters to the circuit. Defaults to None.
+
+        Returns:
+            _type_: _description_
+        """        
+        # In current implementation, circuit is expected to be a function, so we call it to get a QuantumCircuit
+        if callable(circuit):
+            built_circuit = circuit()
+        else:
+            built_circuit = circuit
+
+        print("Running the circuit ...")  # print for debugging. TODO: later we can define a verbose mode
+        if self.shots is not None:
+            job = self.backend.run(built_circuit, shots=self.shots)
+        else:
+            job = self.backend.run(built_circuit)
+        return job.result()

--- a/src/adapters/qiskit_adapter.py
+++ b/src/adapters/qiskit_adapter.py
@@ -11,15 +11,16 @@ class QiskitAdapter(MQSSAdapter):
         if not isinstance(config, dict):
             raise TypeError("config must be a dict")
         backend_name = str(config.get("backend", "") or MQSS_BACKEND).strip()
+        if not backend_name:
+            raise ValueError("Missing required config: backend or MQSS_BACKEND")
         credentials = config.get("credentials") or {}
         token = (credentials.get("mqss_token") if isinstance(credentials, dict) else None) or MQSS_TOKEN
         if not token:
             raise ValueError("Missing required config: credentials.mqss_token or MQSS_TOKEN")
-        if not backend_name:
-            raise ValueError("Missing required config: backend or MQSS_BACKEND")
+        self.shots = int(config["shots"]) if config.get("shots") is not None else None
+        
         self.adapter = MQSSQiskitAdapter(token=token)
         self.backend = self.adapter.get_backend(backend_name)
-        self.shots = int(config["shots"]) if config.get("shots") is not None else None
         #TODO: consider using config["wires"], which is number of qubits
 
     def run_circuit(self, circuit, params=None):
@@ -32,7 +33,7 @@ class QiskitAdapter(MQSSAdapter):
         Returns:
             _type_: _description_
         """        
-        # In current implementation, circuit is expected to be a function, so we call it to get a QuantumCircuit
+        # In current implementation, circuit is a function, so we call it to get a QuantumCircuit
         if callable(circuit):
             built_circuit = circuit()
         else:
@@ -43,4 +44,4 @@ class QiskitAdapter(MQSSAdapter):
             job = self.backend.run(built_circuit, shots=self.shots)
         else:
             job = self.backend.run(built_circuit)
-        return job.result()
+        return job.result().get_counts()

--- a/src/circuits/hw_circuits.py
+++ b/src/circuits/hw_circuits.py
@@ -1,10 +1,15 @@
-def get_hw_circuit(name: str):
+def get_hw_circuit(name: str, interface: str = "pennylane"):
     if name == "randomized_benchmarking":
-        return randomized_benchmarking_circuit
+        if interface == "pennylane":
+            return randomized_benchmarking_circuit_pennylane
+        elif interface == "qiskit":
+            return randomized_benchmarking_circuit_qiskit
+        else:
+            raise ValueError(f"Unsupported interface for HW benchmark: {interface}")
     raise ValueError(f"Unsupported HW benchmark: {name}")
 
 
-def randomized_benchmarking_circuit(device):
+def randomized_benchmarking_circuit_pennylane(device):
     import pennylane as qml
     import numpy as np
 
@@ -28,5 +33,17 @@ def randomized_benchmarking_circuit(device):
 
         return qml.expval(qml.PauliZ(0))
         return qml.expval(hamiltonian)
+
+    return circuit
+
+
+def randomized_benchmarking_circuit_qiskit():
+    from qiskit import QuantumCircuit
+
+    # TODO1: Example circuit — replace with real RB
+    circuit = QuantumCircuit(2, 2)
+    circuit.h(0)
+    circuit.cx(0, 1)
+    circuit.measure([0, 1], [0, 1])
 
     return circuit

--- a/src/handlers/hw_handler.py
+++ b/src/handlers/hw_handler.py
@@ -12,12 +12,16 @@ class HardwareBenchmarkHandler(BenchmarkHandler):
 
         backend = get_adapter(self.config)
 
-        # 2. Get the circuit function for the requested benchmark
+        # 1. Get benchmark config
         benchmark_name = self.config["benchmark_name"]
-        circuit_fn = get_hw_circuit(benchmark_name)
+        interface = self.config.get("interface", "pennylane")
+        params = self.config.get("params")
+
+        # 2. Get the circuit function for the requested benchmark
+        circuit_fn = get_hw_circuit(benchmark_name, interface)
 
         # 3. Execute the circuit using the unified backend interface
-        result = backend.run_circuit(circuit_fn, **self.config["params"])
+        result = backend.run_circuit(circuit_fn, **params)
 
         # 4. Return or log the result
         return {"benchmark": benchmark_name, "result": result}

--- a/src/handlers/sw_handler.py
+++ b/src/handlers/sw_handler.py
@@ -9,7 +9,7 @@ class SoftwareBenchmarkHandler(BenchmarkHandler):
         backend = get_adapter(self.config)
 
         name = self.config["benchmark_name"]
-        num_qubits = self.config["benchmark_name"]
+        num_qubits = self.config["wires"]
         # TODO: Indicate which modules have to be benchmarked through the config
         circuit_fn = get_sw_benchmark_by_name(name, num_qubits)
 


### PR DESCRIPTION
This PR adds support for the Qiskit adapter, enabling execution of circuits through this interface:

- Implementation of the `QiskitAdapter` class.
- Added support for applying configuration passed via the `config` parameter, for both Qiskit and PennyLane adapters.
- Added `shots` option to the configuration for circuit execution.
- Minor improvements and updated documentation.

Closes #4 