### PR TITLE
Add -v/-vv CLI logging verbosity

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,19 +5,16 @@
   />
 </a>
 
-
-
 # MQSS Benchmarking Framework
 
 ## Overview
 
-MQSS Benchmarking Framework is an automated and reproducable tool for uniting Quantum Computing Benchmarks. It has 4 main pillars: 
+MQSS Benchmarking Framework is an automated and reproducable tool for uniting Quantum Computing Benchmarks. It has 4 main pillars:
 
 - Hardware Benchmarks
 - Software Benchmarks
 - Simulator Benchmarks
 - Algorithmic Benchmarks
-
 
 ## 🛠️ Installation
 
@@ -36,8 +33,6 @@ To get started, ensure you have Python installed. Then, follow these steps to se
    uv sync
    ```
 
-   This will install all required dependencies as specified in the project configuration.
-
 ## 🚀 Usage
 
 MQSS Benchmarking Framework can be used in two ways: through a simple command-line interface or directly as a Python library.
@@ -46,7 +41,7 @@ MQSS Benchmarking Framework can be used in two ways: through a simple command-li
 
 After installation, the command `mqssbench` becomes available system-wide.
 
-**List all available benchmarks**
+### Listing benchmarks
 
 ```bash
 mqssbench list
@@ -54,24 +49,23 @@ mqssbench list
 
 This prints every benchmark registered under the `origin/source/name` structure, including internal, external and user-defined benchmarks.
 
-**Run a benchmark from a config file**
+### Running benchmarks
 
 ```bash
 mqssbench run --config path/to/config.yaml
 ```
 
-**Note:**
 The `--config` file may contain either:
-
-1. a **single benchmark configuration** (dict)
-2. or a **list of benchmark configurations** (each a full config dict)
+1. a single benchmark configuration (dict)
+2. or a list of benchmark configurations (each a full config dict)
 
 When a list is provided, mqssbench runs each benchmark sequentially using the same execution engine.
 
-Example of running a config file:
+In development setups, you can run the CLI commands through `uv`:
 
 ```bash
-mqssbench run --config examples/config_qv.yaml
+uv run mqssbench list
+uv run mqssbench run --config path/to/config.yaml
 ```
 
 To explore all available commands and options:
@@ -80,8 +74,29 @@ To explore all available commands and options:
 mqssbench --help
 ```
 
-Your YAML file temp may look like:
-Note: This template will be the structure of future versions and the current structure might be slightly different
+### Verbosity and logging
+
+The CLI supports adjustable logging verbosity for debugging and inspection.
+
+Default behavior shows only warnings and errors.
+
+Increase verbosity with `-v` or `--verbose`:
+
+```bash
+mqssbench run --config path/to/config.yaml -v
+```
+
+Enable debug level logging with `-vv`:
+
+```bash
+mqssbench run --config path/to/config.yaml -vv
+```
+
+Benchmark results are printed to standard output, while logs are sent to standard error.
+
+### Configuration file format
+
+A typical benchmark configuration file follows the structure shown below:
 
 ```yaml
 # Benchmark configuration template
@@ -249,6 +264,6 @@ A complete list of configuration options will be listed and constantly updated f
 ## 🛠️ Upcoming Features
 - Integration of the [Toolchain Project]([https://pages.github.com/](https://gitlab.lrz.de/qcbm/benchmark-comparison)) to the Framework for Simulator Benchmarks
 - Improving the benchmark set for all types of benchmarks
-## Contributing
+## 📝 Contributing
 
 Feel free to open issues or submit pull requests to improve this project!

--- a/README.md
+++ b/README.md
@@ -78,17 +78,18 @@ mqssbench --help
 
 The CLI supports adjustable logging verbosity for debugging and inspection.
 
-Default behavior shows only warnings and errors.
+By default, only warnings and errors are shown.
 
-Set verbosity with `--verbose=<n>` or the short alias `-v` where:
-- `0` = WARNING (default)
-- `1` = INFO
-- `>=2` = DEBUG
+Increase verbosity by repeating the `-v` / `--verbose` flag:
+
+- No `-v` → WARNING (default)
+- `-v` → INFO
+- `-vv` → DEBUG
 
 Examples:
 ```bash
-mqssbench run --verbose=1 --config=path/to/config.yaml
-mqssbench run -v 2 -c path/to/config.yaml
+mqssbench run -v --config path/to/config.yaml
+mqssbench run -vv --config path/to/config.yaml
 ```
 
 Benchmark results are printed to standard output, while logs are sent to standard error.

--- a/README.md
+++ b/README.md
@@ -80,16 +80,15 @@ The CLI supports adjustable logging verbosity for debugging and inspection.
 
 Default behavior shows only warnings and errors.
 
-Increase verbosity with `-v` or `--verbose`:
+Set verbosity with `--verbose=<n>` or the short alias `-v` where:
+- `0` = WARNING (default)
+- `1` = INFO
+- `>=2` = DEBUG
 
+Examples:
 ```bash
-mqssbench run --config path/to/config.yaml -v
-```
-
-Enable debug level logging with `-vv`:
-
-```bash
-mqssbench run --config path/to/config.yaml -vv
+mqssbench run --verbose=1 --config=path/to/config.yaml
+mqssbench run -v 2 -c path/to/config.yaml
 ```
 
 Benchmark results are printed to standard output, while logs are sent to standard error.

--- a/examples/run_example.py
+++ b/examples/run_example.py
@@ -20,7 +20,9 @@ config = {
 }
 
 manager = BenchmarkManager(config)
-result = manager.dispatch()
+results = manager.dispatch()
 
 print("\n===== Benchmark Result =====")
-print(format_benchmark_result(result))
+for r in results:
+    print(format_benchmark_result(r))
+    print()  # blank line between runs

--- a/src/mqssbench/cli/__main__.py
+++ b/src/mqssbench/cli/__main__.py
@@ -10,15 +10,16 @@ logger = logging.getLogger(__name__)
 
 def setup_logging(verbosity: int):
     """
-    Map repeatable -v to logging levels:
-      no -v -> WARNING
-      -v     -> INFO
-      -vv    -> DEBUG
+    Map numeric verbosity to logging levels:
+      0 -> WARNING
+      1 -> INFO
+      >=2 -> DEBUG
     Logs are sent to stderr so stdout remains for program output.
     """
-    if verbosity >= 2:
+    v = max(0, int(verbosity))
+    if v >= 2:
         level = logging.DEBUG
-    elif verbosity == 1:
+    elif v == 1:
         level = logging.INFO
     else:
         level = logging.WARNING
@@ -54,14 +55,36 @@ def cli_list():
     )
     print(formatted)
 
+def non_negative_int(value: str) -> int:
+    """
+    argparse type for non negative integers. Raises ArgumentTypeError on invalid input.
+    """
+    try:
+        iv = int(value)
+    except ValueError:
+        raise argparse.ArgumentTypeError(f"invalid int value: {value!r}")
+    if iv < 0:
+        raise argparse.ArgumentTypeError("verbosity must be a non-negative integer")
+    return iv
+
 def main():
-    parser = argparse.ArgumentParser(prog="mqssbench")
+    EXAMPLES = """Examples:
+    mqssbench list
+    mqssbench run --verbose=1 --config=path/to/config.yaml
+    mqssbench run -v 2 -c path/to/config.yaml
+    """
+    parser = argparse.ArgumentParser(
+        prog="mqssbench",
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+        epilog=EXAMPLES)
+
     parser.add_argument(
         "-v",
         "--verbose",
-        action="count",
+        type=non_negative_int,
         default=0,
-        help="Increase verbosity (-v, -vv)"
+        metavar="LEVEL",
+        help="Set verbosity level (integer). 0=WARNING, 1=INFO, 2=DEBUG. Default is 0."
     )
 
     subparsers = parser.add_subparsers(dest="command")
@@ -75,8 +98,9 @@ def main():
 
     args = parser.parse_args()
 
-    # configure logging based on parsed verbosity
-    setup_logging(args.verbose)
+    # resolve and configure logging
+    verbosity = args.verbose
+    setup_logging(verbosity)
 
     if args.command == "run":
         cli_run(args.config)

--- a/src/mqssbench/cli/__main__.py
+++ b/src/mqssbench/cli/__main__.py
@@ -7,11 +7,27 @@ from mqssbench.runtime.benchmark_manager import BenchmarkManager
 from mqssbench.cli.formatting import format_benchmark_result, format_registry_lists
 
 logger = logging.getLogger(__name__)
-logging.basicConfig(
-    stream=sys.stdout, 
-    level=logging.WARNING,
-    format="[%(levelname)s] %(name)s: %(message)s"
-)
+
+def setup_logging(verbosity: int):
+    """
+    Map repeatable -v to logging levels:
+      no -v -> WARNING
+      -v     -> INFO
+      -vv    -> DEBUG
+    Logs are sent to stderr so stdout remains for program output.
+    """
+    if verbosity >= 2:
+        level = logging.DEBUG
+    elif verbosity == 1:
+        level = logging.INFO
+    else:
+        level = logging.WARNING
+
+    logging.basicConfig(
+        level=level,
+        stream=sys.stderr,
+        format="[%(levelname)s] %(name)s: %(message)s"
+    )
 
 def cli_run(config_path: str):
     if not config_path:
@@ -28,7 +44,7 @@ def cli_run(config_path: str):
 
     for r in results:
         print(format_benchmark_result(r))
-        print()  # blank line between runs    
+        print()  # blank line between runs
 
 def cli_list():
     formatted = format_registry_lists(
@@ -40,6 +56,14 @@ def cli_list():
 
 def main():
     parser = argparse.ArgumentParser(prog="mqssbench")
+    parser.add_argument(
+        "-v",
+        "--verbose",
+        action="count",
+        default=0,
+        help="Increase verbosity (-v, -vv)"
+    )
+
     subparsers = parser.add_subparsers(dest="command")
 
     # mqssbench run
@@ -50,6 +74,9 @@ def main():
     subparsers.add_parser("list", help="List available benchmarks, circuit providers, and adapters")
 
     args = parser.parse_args()
+
+    # configure logging based on parsed verbosity
+    setup_logging(args.verbose)
 
     if args.command == "run":
         cli_run(args.config)

--- a/src/mqssbench/cli/__main__.py
+++ b/src/mqssbench/cli/__main__.py
@@ -10,13 +10,14 @@ logger = logging.getLogger(__name__)
 
 def setup_logging(verbosity: int):
     """
-    Map numeric verbosity to logging levels:
+    Map repeatable verbosity to logging levels:
       0 -> WARNING
       1 -> INFO
       >=2 -> DEBUG
     Logs are sent to stderr so stdout remains for program output.
     """
-    v = max(0, int(verbosity))
+    v = verbosity or 0
+
     if v >= 2:
         level = logging.DEBUG
     elif v == 1:
@@ -45,7 +46,7 @@ def cli_run(config_path: str):
 
     for r in results:
         print(format_benchmark_result(r))
-        print()  # blank line between runs
+        print()
 
 def cli_list():
     formatted = format_registry_lists(
@@ -55,52 +56,40 @@ def cli_list():
     )
     print(formatted)
 
-def non_negative_int(value: str) -> int:
-    """
-    argparse type for non negative integers. Raises ArgumentTypeError on invalid input.
-    """
-    try:
-        iv = int(value)
-    except ValueError:
-        raise argparse.ArgumentTypeError(f"invalid int value: {value!r}")
-    if iv < 0:
-        raise argparse.ArgumentTypeError("verbosity must be a non-negative integer")
-    return iv
-
 def main():
     EXAMPLES = """Examples:
     mqssbench list
-    mqssbench run --verbose=1 --config=path/to/config.yaml
-    mqssbench run -v 2 -c path/to/config.yaml
+    mqssbench run --config path/to/config.yaml
+    mqssbench run -v --config path/to/config.yaml
     """
+
     parser = argparse.ArgumentParser(
         prog="mqssbench",
         formatter_class=argparse.RawDescriptionHelpFormatter,
-        epilog=EXAMPLES)
+        epilog=EXAMPLES
+    )
 
     parser.add_argument(
         "-v",
         "--verbose",
-        type=non_negative_int,
+        action="count",
         default=0,
-        metavar="LEVEL",
-        help="Set verbosity level (integer). 0=WARNING, 1=INFO, 2=DEBUG. Default is 0."
+        help="Increase verbosity (-v, -vv)."
     )
 
     subparsers = parser.add_subparsers(dest="command")
 
-    # mqssbench run
     run_parser = subparsers.add_parser("run", help="Run a benchmark from config file")
     run_parser.add_argument("-c", "--config", required=True, help="Path to config YAML")
 
-    # mqssbench list
-    subparsers.add_parser("list", help="List available benchmarks, circuit providers, and adapters")
+    subparsers.add_parser(
+        "list",
+        help="List available benchmarks, circuit providers, and adapters"
+    )
 
     args = parser.parse_args()
 
-    # resolve and configure logging
-    verbosity = args.verbose
-    setup_logging(verbosity)
+    setup_logging(args.verbose)
 
     if args.command == "run":
         cli_run(args.config)


### PR DESCRIPTION
This PR adds `-v` / `-vv` flags to the `mqssbench` CLI to control logging verbosity.

- No `-v` → WARNING level logs (default)
- `-v` → INFO level logs
- `-vv` → DEBUG level logs

Changes included:
- Implement `-v` / `--verbose` as a repeatable flag
- Update README CLI Usage section with verbosity instructions and minor general improvements
- Update `examples/run_example.py` to match the latest result structure after the multi-config feature
  (Related to PR #23)