### PR TITLE
Introduce benchmark storage system (with initial FileStorage)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,7 @@ wheels/
 
 # Datasets
 datasets/
+mqssbench.db
 *.h5
 
 # Results

--- a/README.md
+++ b/README.md
@@ -88,8 +88,8 @@ Increase verbosity by repeating the `-v` / `--verbose` flag:
 
 Examples:
 ```bash
-mqssbench run -v --config path/to/config.yaml
-mqssbench run -vv --config path/to/config.yaml
+mqssbench -v run --config path/to/config.yaml
+mqssbench -vv run --config path/to/config.yaml
 ```
 
 Benchmark results are printed to standard output, while logs are sent to standard error.
@@ -139,10 +139,11 @@ report:
 
 # Controls how results are persisted
 storage:
+  enabled: <true_or_false>
   type: <STORAGE_TYPE>  # "file" or "sqlite"
   file:
     format: <FILE_FORMAT> #"json"
-  sqlite:
+  sqlite: # this will be implemeted in future
     db_path: <DATABASE_PATH>
 
 # Profiling controls
@@ -186,6 +187,7 @@ report:
       show: false
 
 storage:
+  enabled: true
   type: "file" 
   file:
     format: "json"
@@ -213,6 +215,7 @@ Example of a multi benchmark config:
   shots: 200
   output_dir: "./results"
   storage:
+    enabled: true
     type: "file" 
     file:
       format: "json"
@@ -229,6 +232,7 @@ Example of a multi benchmark config:
   shots: 200
   output_dir: "./results"
   storage:
+    enabled: true
     type: "file" 
     file:
       format: "json"
@@ -265,14 +269,15 @@ config = {
 
   "report": {
     "analysis": {
-      "enabled": true,
+      "enabled": True,
       "visualization": {
-        "enabled": true
+        "enabled": True
       }
     }
   },
 
   "storage": {
+    "enabled": True,
     "type": "file",
     "file": {
       "format": "json"
@@ -280,7 +285,7 @@ config = {
   },
   
   "profiling": {
-    "enabled": true,
+    "enabled": True,
     "metrics": ["transpiler", "submitter"]
   }
 }

--- a/README.md
+++ b/README.md
@@ -126,12 +126,24 @@ credentials:
 # Number of measurement shots
 shots: <NUM_SHOTS>
 
-# Output controls
-output:
-  analysis: <true_or_false>
-  visualization: <true_or_false>
-  save: <true_or_false>
-  output_dir: <PATH>
+# output directory
+output_dir: <PATH>
+
+# Controls what is generated (analysis, visualizations, reports)
+report:
+  analysis:
+    enabled: <true_or_false>
+      visualization: <true_or_false>
+        enabled: <true_or_false>
+        show: <true_or_false>
+
+# Controls how results are persisted
+storage:
+  type: <STORAGE_TYPE>  # "file" or "sqlite"
+  file:
+    format: <FILE_FORMAT> #"json"
+  sqlite:
+    db_path: <DATABASE_PATH>
 
 # Profiling controls
 profiling:
@@ -164,11 +176,19 @@ credentials:
 
 shots: 1000
 
-output:
-  analysis: true
-  visualization: true
-  save: true
-  output_dir: "./results"
+output_dir: "./results"
+
+report:
+  analysis:
+    enabled: true
+    visualization:
+      enabled: true
+      show: false
+
+storage:
+  type: "file" 
+  file:
+    format: "json"
 
 profiling:
   enabled: true
@@ -191,6 +211,11 @@ Example of a multi benchmark config:
   credentials:
     mqss_token: ""
   shots: 200
+  output_dir: "./results"
+  storage:
+    type: "file" 
+    file:
+      format: "json"
 
 - benchmark: core/native/quantum_volume
   benchmark_params:
@@ -202,6 +227,11 @@ Example of a multi benchmark config:
   credentials:
     mqss_token: ""
   shots: 200
+  output_dir: "./results"
+  storage:
+    type: "file" 
+    file:
+      format: "json"
 ```
 
 ## 🧩 Python API Usage
@@ -231,13 +261,24 @@ config = {
 
   "shots": 1000,
 
-  "output": {
-    "analysis": true,
-    "visualization": true,
-    "save": true,
-    "output_dir": "./results"
+  "output_dir": "./results"
+
+  "report": {
+    "analysis": {
+      "enabled": true,
+      "visualization": {
+        "enabled": true
+      }
+    }
   },
 
+  "storage": {
+    "type": "file",
+    "file": {
+      "format": "json"
+    }
+  },
+  
   "profiling": {
     "enabled": true,
     "metrics": ["transpiler", "submitter"]

--- a/README.md
+++ b/README.md
@@ -138,7 +138,8 @@ profiling:
   enabled: <true_or_false>
   metrics:
     # List of profiling metrics. If omitted, all supported metrics are collected.
-    # Valid metrics:
+    # Available metrics depend on your selected adaptor.
+    # For example, for MQSS adaptors, these are valid metrics:
     #   mqp_api, quantum_database, quantum_job_runner, isv_job_runner,
     #   quantum_daemon_job_runner, generator, scheduler, pass_runner,
     #   transpiler, submitter, pass_selection, knitter, job_execution

--- a/examples/config_mqt_vqe.yaml
+++ b/examples/config_mqt_vqe.yaml
@@ -1,4 +1,3 @@
-version: "0.1"
 benchmark: core/mqt_bench/vqe_su2
 
 benchmark_params:
@@ -25,6 +24,7 @@ report:
 
 # Controls how results are persisted
 storage:
+  enabled: true
   type: "file"  # "file" or "sqlite"
   file:
     format: "json"

--- a/examples/config_mqt_vqe.yaml
+++ b/examples/config_mqt_vqe.yaml
@@ -1,3 +1,4 @@
+version: "0.1"
 benchmark: core/mqt_bench/vqe_su2
 
 benchmark_params:
@@ -12,11 +13,23 @@ credentials:
 
 shots: 200
 
-output:
-  analysis: true
-  visualization: true  # only applies if enabled is true
-  save: true
-  output_dir: "./results"
+output_dir: "./results"
+
+# Controls what is generated
+report:
+  analysis:
+    enabled: true
+    visualization:
+      enabled: true
+      show: true
+
+# Controls how results are persisted
+storage:
+  type: "file"  # "file" or "sqlite"
+  file:
+    format: "json"
+  sqlite:
+    db_path: "./mqssbench.db"
 
 profiling:
   enabled: true

--- a/examples/config_multi.yaml
+++ b/examples/config_multi.yaml
@@ -10,11 +10,11 @@
   credentials:
     mqss_token: ""
   shots: 200
-  output:
-    analysis: true
-    visualization: true
-    save: true
-    output_dir: "./results"
+  output_dir: "./results"
+  storage:
+    type: "file" 
+    file:
+      format: "json"
 
 - benchmark: core/native/quantum_volume
   benchmark_params:
@@ -26,11 +26,11 @@
   credentials:
     mqss_token: ""
   shots: 200
-  output:
-    analysis: true
-    visualization: false
-    save: true
-    output_dir: "./results"
+  output_dir: "./results"
+  storage:
+    type: "file" 
+    file:
+      format: "json"
 
 - benchmark: core/mqt_bench/vqe_su2
   benchmark_params:
@@ -41,8 +41,8 @@
   credentials:
     mqss_token: ""
   shots: 200
-  output:
-    analysis: true
-    visualization: true
-    save: true
-    output_dir: "./results"
+  output_dir: "./results"
+  storage:
+    type: "file" 
+    file:
+      format: "json"

--- a/examples/config_multi.yaml
+++ b/examples/config_multi.yaml
@@ -12,7 +12,8 @@
   shots: 200
   output_dir: "./results"
   storage:
-    type: "file" 
+    enabled: true
+    type: "file"
     file:
       format: "json"
 
@@ -28,7 +29,8 @@
   shots: 200
   output_dir: "./results"
   storage:
-    type: "file" 
+    enabled: true
+    type: "file"
     file:
       format: "json"
 
@@ -43,6 +45,7 @@
   shots: 200
   output_dir: "./results"
   storage:
-    type: "file" 
+    enabled: true
+    type: "file"
     file:
       format: "json"

--- a/examples/config_qv.yaml
+++ b/examples/config_qv.yaml
@@ -13,5 +13,13 @@ credentials:
 
 shots: 200
 
+output_dir: "./results"
+
+# Controls how results are persisted
+storage:
+  type: "file" 
+  file:
+    format: "json"
+
 profiling:
   enabled: true

--- a/examples/config_qv.yaml
+++ b/examples/config_qv.yaml
@@ -17,6 +17,7 @@ output_dir: "./results"
 
 # Controls how results are persisted
 storage:
+  enabled: true
   type: "file" 
   file:
     format: "json"

--- a/examples/config_rb.yaml
+++ b/examples/config_rb.yaml
@@ -25,6 +25,7 @@ report:
 
 # Controls how results are persisted
 storage:
+  enabled: true
   type: "file"  # "file" or "sqlite"
   file:
     format: "json"

--- a/examples/config_rb.yaml
+++ b/examples/config_rb.yaml
@@ -13,12 +13,24 @@ credentials:
 
 shots: 200
 
-output:
-  analysis: true
-  visualization: true  # only applies if enabled is true
-  save: true
-  output_dir: "./results"
+output_dir: "./results"
 
+# Controls what is generated
+report:
+  analysis:
+    enabled: true
+    visualization:
+      enabled: true
+      show: true
+
+# Controls how results are persisted
+storage:
+  type: "file"  # "file" or "sqlite"
+  file:
+    format: "json"
+  sqlite:
+    db_path: "./mqssbench.db"
+  
 profiling:
   enabled: true
   metrics: # not defining metrics means all of them are requested

--- a/examples/custom_benchmark.py
+++ b/examples/custom_benchmark.py
@@ -42,9 +42,12 @@ class CustomAnalyzer(BenchmarkAnalyzer):
         counts = result.counts
         total = sum(counts.values())
         p_zero = counts.get("0", 0) / total if total > 0 else 0.0
-        return AnalysisResult({
-            "p_zero": p_zero,
-        })
+        return AnalysisResult(
+            metrics={
+                "p_zero": p_zero,
+            },
+            artifacts={},
+        )
 
 
 @BenchmarkRegistry.register_benchmark
@@ -71,15 +74,18 @@ if __name__ == "__main__":
 
     config = {
         "benchmark": "user/my_examples/custom_benchmark",
+        "benchmark_params": {"num_qubits": 1, "depth": 3},
         "adapter": "mqss_qiskit",
         "backend": "QExa20",
         "credentials": {"mqss_token": ""},
         "shots": 200,
-        "benchmark_params": {"num_qubits": 1, "depth": 3},
+        "output_dir": "./results",
     }
 
     manager = BenchmarkManager(config)
-    result = manager.dispatch()
+    results = manager.dispatch()
 
     print("===== Custom Benchmark Result =====")
-    print(format_benchmark_result(result))
+    for r in results:
+        print(format_benchmark_result(r))
+        print()  # blank line between runs

--- a/examples/run_example.py
+++ b/examples/run_example.py
@@ -19,6 +19,7 @@ config = {
     "shots": 200,
     "output_dir": "./results",
     "storage": {
+        "enabled": True,
         "type": "file",
         "file": {
             "format": "json"

--- a/examples/run_example.py
+++ b/examples/run_example.py
@@ -17,6 +17,13 @@ config = {
     "backend": "QExa20",
     "credentials": {"mqss_token": ""},
     "shots": 200,
+    "output_dir": "./results",
+    "storage": {
+        "type": "file",
+        "file": {
+            "format": "json"
+        }
+    }
 }
 
 manager = BenchmarkManager(config)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,6 +15,7 @@ dependencies = [
     "qiskit-aer>=0.13.3",
     "pyyaml>=6.0.3",
     "colorama>=0.4.6",
+    "dacite>=1.9.2",
 ]
 
 # for PyPy

--- a/src/mqssbench/cli/__main__.py
+++ b/src/mqssbench/cli/__main__.py
@@ -60,7 +60,7 @@ def main():
     EXAMPLES = """Examples:
     mqssbench list
     mqssbench run --config path/to/config.yaml
-    mqssbench run -v --config path/to/config.yaml
+    mqssbench -v run --config path/to/config.yaml
     """
 
     parser = argparse.ArgumentParser(

--- a/src/mqssbench/cli/formatting.py
+++ b/src/mqssbench/cli/formatting.py
@@ -27,6 +27,7 @@ def format_benchmark_result(result: BenchmarkResult) -> str:
 
         for idx, ex in enumerate(exec_results):
             parts.append(f"  {Fore.GREEN}Execution {idx + 1}:{Style.RESET_ALL}")
+            parts.append(f"    Job ID: {ex.job_id}")
             parts.append("    Counts:")
             for state, count in ex.counts.items():
                 parts.append(f"      {state}: {count}")

--- a/src/mqssbench/cli/formatting.py
+++ b/src/mqssbench/cli/formatting.py
@@ -11,6 +11,7 @@ def format_benchmark_result(result: BenchmarkResult) -> str:
     parts = []
 
     # header
+    parts.append(f"{Fore.CYAN}{Style.BRIGHT}Run ID: {Style.RESET_ALL}{result.run_id}")
     parts.append(f"{Fore.CYAN}{Style.BRIGHT}Benchmark: {Style.RESET_ALL}{result.benchmark_key}")
 
     # parameters
@@ -38,10 +39,25 @@ def format_benchmark_result(result: BenchmarkResult) -> str:
                     parts.append(f"      {pkey}: {pval}")
 
     # analysis
-    if result.analysis_result and result.analysis_result.results:
+    if result.analysis_result:
         parts.append(f"{Fore.MAGENTA}Analysis:{Style.RESET_ALL}")
-        for key, value in result.analysis_result.results.items():
-            parts.append(f"  {Fore.WHITE}{key}{Style.RESET_ALL}: {value}")
+
+        # metrics
+        if result.analysis_result.metrics:
+            parts.append(f"  {Fore.MAGENTA}Metrics:")
+            for key, value in result.analysis_result.metrics.items():
+                parts.append(f"    {Fore.WHITE}{key}{Style.RESET_ALL}: {value}")
+
+        # artifacts
+        if result.analysis_result.artifacts:
+            parts.append(f"  {Fore.MAGENTA}Artifacts:")
+            for name, path in result.analysis_result.artifacts.items():
+                parts.append(f"    {Fore.WHITE}{name}{Style.RESET_ALL}: {path}")
+
+    parts.append("")  # blank line for separation
+
+    if result.storage_location:
+        parts.append(f"{Fore.CYAN}{Style.BRIGHT}Stored at:{Style.RESET_ALL} {result.storage_location}")
 
     return "\n".join(parts)
 

--- a/src/mqssbench/framework/__init__.py
+++ b/src/mqssbench/framework/__init__.py
@@ -8,7 +8,7 @@ from .types import (
     ExecutionResult,
     AnalysisResult,
     BenchmarkResult,
-    OutputConfig,
+    ReportConfig,
 )
 from .circuit_generator import CircuitGenerator
 from .benchmark_executor import BenchmarkExecutor, DefaultBenchmarkExecutor
@@ -28,7 +28,7 @@ __all__ = [
     "ExecutionResult",
     "AnalysisResult",
     "BenchmarkResult",
-    "OutputConfig",    
+    "ReportConfig",
     "CircuitGenerator",
     "BenchmarkExecutor",
     "DefaultBenchmarkExecutor",

--- a/src/mqssbench/framework/benchmark.py
+++ b/src/mqssbench/framework/benchmark.py
@@ -71,11 +71,12 @@ class Benchmark(ABC):
         excecution_results = executor.run(circuits, self.context)
 
         analysis_result = None
-        if(self.context.output_config.analysis):
+        if(self.context.report_config.analysis.enabled):
             analyzer = self._instantiate_component(self.analyzer, BenchmarkAnalyzer)
             analysis_result = analyzer.analyze(excecution_results, self.context)
 
         return BenchmarkResult(
+            run_id = self.context.run_id,
             benchmark_key = self.context.benchmark_key,
             params = self.context.params,
             execution_results = excecution_results,

--- a/src/mqssbench/framework/benchmark_analyzer.py
+++ b/src/mqssbench/framework/benchmark_analyzer.py
@@ -6,7 +6,7 @@ from collections import Counter
 import matplotlib.pyplot as plt
 
 from .types import RunContext, ExecutionResult, AnalysisResult
-from .utils import make_output_path, safe_plot_show
+from .utils import make_output_filepath
 
 class BenchmarkAnalyzer(ABC):
     """Abstract base class for benchmark analyzers."""
@@ -40,14 +40,19 @@ class DefaultAnalyzer(BenchmarkAnalyzer):
         probabilities = {k: v / total_shots for k, v in combined.items()} if total_shots else {}
         most_frequent = max(combined, key=combined.get) if combined else None
 
-        if context.output_config.visualization:
-            self._plot(probabilities, context)
+        artifacts = {}
+        if context.report_config.analysis.visualization.enabled:
+            plot_filename = self._plot(probabilities, context)
+            artifacts["plot"] = plot_filename
 
-        return AnalysisResult({
-            "total_shots": total_shots,
-            "probabilities": probabilities,
-            "most_frequent": most_frequent,
-        })
+        return AnalysisResult(
+            metrics={
+                "total_shots": total_shots,
+                "probabilities": probabilities,
+                "most_frequent": most_frequent,
+            },
+            artifacts=artifacts,
+        )
 
     def _plot(self, probabilities: dict, context: RunContext) -> None:
         """Simple probability bar plot."""
@@ -68,10 +73,7 @@ class DefaultAnalyzer(BenchmarkAnalyzer):
 
         plt.bar(outcomes, probs)
 
-        if context.output_config.save:
-            bench_name = context.benchmark_key.split("/")[-1]
-            filename = make_output_path(name=bench_name, output_dir=context.output_config.output_dir, is_plot=True)
-            plt.savefig(filename)
+        filename = make_output_filepath(context.benchmark_key, context.run_dir, tag="plot")
+        plt.savefig(filename)
 
-        # safe plot show to avoid calling plt.show() which blocks in In CI / headless environments
-        safe_plot_show()
+        return filename

--- a/src/mqssbench/framework/benchmark_executor.py
+++ b/src/mqssbench/framework/benchmark_executor.py
@@ -38,6 +38,7 @@ class DefaultBenchmarkExecutor(BenchmarkExecutor):
             
             # set metadata in in new instance for immutability
             run_result = ExecutionResult(
+                job_id=run_result.job_id,
                 counts=run_result.counts,
                 profiling_metrics=run_result.profiling_metrics,
                 metadata=dict(spec.metadata)

--- a/src/mqssbench/framework/types.py
+++ b/src/mqssbench/framework/types.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 from dataclasses import dataclass, field
 from enum import StrEnum, auto
 from typing import Any, Dict, Optional, Literal, TYPE_CHECKING
+from pathlib import Path
 if TYPE_CHECKING:
     from mqssbench.framework.adapter import DeviceAdapter
 
@@ -79,12 +80,16 @@ class SqliteStorageConfig:
         # Ensure the path is not empty
         if not self.db_path:
             raise ValueError("db_path must be provided for sqlite storage")
-
+        # Enforce relative path (relative to output_dir) for safety
+        db_path_obj = Path(self.db_path)
+        if db_path_obj.is_absolute():
+            raise ValueError("db_path must be relative to output_dir for safety")
 
 @dataclass(frozen=True)
 class StorageConfig:
     """Configuration for persisting benchmark results."""
-    type: Literal["file", "sqlite"]
+    enabled: bool = False
+    type: Literal["file", "sqlite"] = "file"
     file: Optional[FileStorageConfig] = field(default_factory=FileStorageConfig)
     sqlite: Optional[SqliteStorageConfig] = None  # field(default_factory=SqliteStorageConfig)
 

--- a/src/mqssbench/framework/types.py
+++ b/src/mqssbench/framework/types.py
@@ -4,9 +4,10 @@ from __future__ import annotations
 
 from dataclasses import dataclass, field
 from enum import StrEnum, auto
-from typing import Any, Dict, Optional, TYPE_CHECKING
+from typing import Any, Dict, Optional, Literal, TYPE_CHECKING
 if TYPE_CHECKING:
     from mqssbench.framework.adapter import DeviceAdapter
+
 
 # Valid origins for benchmarks
 VALID_ORIGINS = frozenset({"core", "user"})
@@ -37,31 +38,73 @@ class ProfilingConfig:
 
 
 @dataclass(frozen=True)
-class OutputConfig:
-    """Configuration for saving and handling output results."""
+class VisualizationConfig:
+    enabled: bool = False   # generate visualization artifacts
+    show: bool = False      # display interactively
 
-    analysis: bool = True
-    visualization: bool = False  # only meaningful if analysis is True
-    save: bool = False
-    output_dir: str = ""  # required if save is True
+    def __post_init__(self):
+        if self.show and not self.enabled:
+            raise ValueError("show=True requires visualization.enabled=True")
+
+
+@dataclass(frozen=True)
+class AnalysisConfig:
+    enabled: bool = True
+    visualization: VisualizationConfig = field(
+        default_factory=VisualizationConfig
+    )
+
+
+@dataclass(frozen=True)
+class ReportConfig:
+    """Configuration for generated reports."""
+    analysis: AnalysisConfig = field(default_factory=AnalysisConfig)
 
     def __post_init__(self):
         # Validate that visualization only applies if analysis is enabled
-        if self.visualization and not self.analysis:
+        if self.analysis.visualization.enabled and not self.analysis.enabled:
             raise ValueError("Visualization can only be True if analysis is enabled.")
 
-        # Validate that output_dir is provided if save is True
-        if self.save and not self.output_dir:
-            raise ValueError("output_dir must be provided when save is True.")
+
+@dataclass(frozen=True)
+class FileStorageConfig:
+    format: Literal["json"] = "json"
+
+
+@dataclass(frozen=True)
+class SqliteStorageConfig:
+    db_path: str
+
+    def __post_init__(self):
+        # Ensure the path is not empty
+        if not self.db_path:
+            raise ValueError("db_path must be provided for sqlite storage")
+
+
+@dataclass(frozen=True)
+class StorageConfig:
+    """Configuration for persisting benchmark results."""
+    type: Literal["file", "sqlite"]
+    file: Optional[FileStorageConfig] = field(default_factory=FileStorageConfig)
+    sqlite: Optional[SqliteStorageConfig] = None  # field(default_factory=SqliteStorageConfig)
+
+    def __post_init__(self):
+        # Validate type and corresponding config
+        if self.type == "file" and self.file is None:
+            raise ValueError("file config must be provided when type='file'")
+        if self.type == "sqlite" and self.sqlite is None:
+            raise ValueError("sqlite config must be provided when type='sqlite'")
 
 
 @dataclass(frozen=True)
 class RunContext:
     """Context for a benchmark run."""
+    run_id: str
+    run_dir: str              # to store per-run data/artifacts
     adapter: "DeviceAdapter"  # Forward reference to avoid circular import
     benchmark_key: str
-    params: Dict[str, Any] = field(default_factory=dict)
-    output_config: OutputConfig = field(default_factory=OutputConfig)
+    params: Dict[str, Any] = field(default_factory=dict) # benchmark parameters
+    report_config: ReportConfig = field(default_factory=ReportConfig)
     profiling: Optional[ProfilingConfig] = field(default_factory=ProfilingConfig)
     metadata: Dict[str, Any] = field(default_factory=dict)
 
@@ -84,14 +127,17 @@ class ExecutionResult:
 @dataclass(frozen=True)
 class AnalysisResult:
     """Analysis results from executing a circuit."""
-    results: Dict[str, Any] = field(default_factory=dict)
+    metrics: Dict[str, Any] = field(default_factory=dict)
+    artifacts: Dict[str, str] = field(default_factory=dict)  # name -> filepath
 
 
 @dataclass(frozen=True)
 class BenchmarkResult:
     """Final result from a benchmark run."""
+    run_id: str
     benchmark_key: str
-    params: Dict[str, Any] = field(default_factory=dict)
+    params: Dict[str, Any] = field(default_factory=dict) # benchmark parameters
     execution_results: list[ExecutionResult] = field(default_factory=list)
     analysis_result: Optional[AnalysisResult] = None
     metadata: Dict[str, Any] = field(default_factory=dict)
+    storage_location: Optional[str] = None

--- a/src/mqssbench/framework/types.py
+++ b/src/mqssbench/framework/types.py
@@ -75,6 +75,7 @@ class ProfilingMetrics:
 @dataclass(frozen=True)
 class ExecutionResult:
     """Result from executing a circuit."""
+    job_id: str
     counts: Any
     profiling_metrics: ProfilingMetrics = field(default_factory=ProfilingMetrics)
     metadata: Dict[str, Any] = field(default_factory=dict)

--- a/src/mqssbench/framework/utils.py
+++ b/src/mqssbench/framework/utils.py
@@ -4,9 +4,20 @@ import re
 import sys
 import matplotlib.pyplot as plt
 import matplotlib
-from typing import Iterable
+from typing import Iterable, Callable, IO
 import webbrowser
 from pathlib import Path
+
+
+def atomic_write(target_path: Path, write_fn: Callable[[IO], None], encoding="utf-8"):
+    """
+    Atomically write to a file. Writes to a temp file first then renames it.
+    """
+    temp_path = target_path.with_suffix(".tmp")
+    os.makedirs(target_path.parent, exist_ok=True)
+    with open(temp_path, "w", encoding=encoding) as f:
+        write_fn(f)
+    temp_path.replace(target_path)
 
 
 def validate_benchmark_registry_key(identifier: str) -> None:

--- a/src/mqssbench/framework/utils.py
+++ b/src/mqssbench/framework/utils.py
@@ -1,9 +1,13 @@
 from .types import VALID_ORIGINS
 import os
-from datetime import datetime
+import re
 import sys
 import matplotlib.pyplot as plt
 import matplotlib
+from typing import Iterable
+import webbrowser
+from pathlib import Path
+
 
 def validate_benchmark_registry_key(identifier: str) -> None:
     """
@@ -21,39 +25,56 @@ def validate_benchmark_registry_key(identifier: str) -> None:
     if not source or not name:
         raise ValueError("Source and name segments must be non-empty.")
 
-def make_output_path(name: str, output_dir: str, is_plot: bool) -> str:
-    """Generate a unique output filename for saving figures or data."""
-    if not output_dir:
-        raise ValueError("output_dir must be provided to make_output_path")
-    # ensure output directory exists
-    os.makedirs(output_dir, exist_ok=True)
+def make_output_filepath(
+    benchmark_key: str,
+    run_dir: str,
+    tag: str = "output",
+    ext: str = "png"
+) -> str:
+    """
+    Generate a safe output filename for saving artifacts (plots, diagrams, etc.)
+    inside the run folder. Automatically creates an 'artifacts' subfolder.
 
-    ext = "png"
-    tag = "_plot" if is_plot else ""
-    timestamp = datetime.now().strftime("%Y%m%d_%H%M%S")
-    base = f"{name}{tag}_{timestamp}"
-    path = os.path.join(output_dir, f"{base}.{ext}")
+    Args:
+        benchmark_key: Full benchmark key (e.g., "origin/source/name").
+        run_dir: Run folder where the artifacts subfolder will be created.
+        tag: Descriptive tag for the artifact (plot, diagram, etc.).
+        ext: File extension (default "png").
 
-    # increment if file exists
-    counter = 1
-    while os.path.exists(path):
-        path = os.path.join(output_dir, f"{base}_{counter}.{ext}")
-        counter += 1
+    Returns:
+        Full path to the artifact file.
+    """
+    if not run_dir:
+        raise ValueError("run_dir must be provided to make_output_filepath")
 
-    # print where file is saved
-    print(f"Output {'plot' if is_plot else 'data'} saved to: {path}")
+    # Create artifacts subfolder
+    artifact_dir = os.path.join(run_dir, "artifacts")
+    os.makedirs(artifact_dir, exist_ok=True)
+
+    # Take last part of benchmark_key and sanitize
+    bench_name = benchmark_key.split("/")[-1].lower()
+    safe_name = re.sub(r"[^a-z0-9_]+", "_", bench_name)
+
+    filename = f"{safe_name}_{tag}.{ext}"
+
+    path = os.path.join(artifact_dir, filename)
 
     return path
 
-def safe_plot_show():
+
+IMAGE_EXTENSIONS = {".png", ".jpg", ".jpeg", ".pdf", ".svg"}
+
+def can_display() -> bool:
     """
-    Show a plot when running interactively (e.g., VS Code, Jupyter, local terminal).
-    Close the plot automatically in headless environments (CI, SSH without X11).
+    Determine if the current environment can display artifacts.
+
+    Returns True if running interactively (e.g., VS Code, local terminal) 
+    and a display is available. Returns False in headless environments 
+    (CI, SSH without X11) or if display is disabled via MQSSBENCH_DISPLAY.
     """
-    # Check the env variable
     if os.environ.get("MQSSBENCH_DISPLAY", "1") != "1":
         plt.close()
-        return
+        return False
 
     try:
         interactive_env = (
@@ -62,12 +83,31 @@ def safe_plot_show():
             os.environ.get("WAYLAND_DISPLAY") or
             sys.stdout.isatty()
         )
-
-        if interactive_env:
-            plt.show()
-            return
+        return bool(interactive_env)
     except Exception:
-        pass
+        return False
 
-    # headless / no display
-    plt.close()
+
+def show_artifacts(artifact_paths: Iterable[str], max_files: int = 3):
+    """
+    Open artifacts in the default system viewer, respecting headless environments.
+    
+    Args:
+        artifact_paths: Iterable of file paths to artifacts.
+        max_files: Maximum number of artifacts to open (default 10).
+    """
+    if not can_display():
+        return
+
+    opened = 0
+    for path_str in artifact_paths:
+        if opened >= max_files:
+            break
+
+        path = Path(path_str).resolve()
+        if not path.exists():
+            continue
+        if path.suffix.lower() in IMAGE_EXTENSIONS:
+            webbrowser.open(f"file://{path}")
+            opened += 1
+

--- a/src/mqssbench/library/adapters/mqss/pennylane_adapter.py
+++ b/src/mqssbench/library/adapters/mqss/pennylane_adapter.py
@@ -104,7 +104,7 @@ class PennyLaneAdapter(DeviceAdapter):
             qnode = circuit
 
         job_result_count = qnode()
-
+        # TODO: implement storing job id in pennylane
         if MQSS_PENNYLANE_PROFILING_ENABLED:
             # To be implemented: get profiling data from job_profiler_metrics
             profiling_data = {}  # Placeholder for actual profiling data retrieval
@@ -112,6 +112,7 @@ class PennyLaneAdapter(DeviceAdapter):
         else:
             profiling_data = None
         return ExecutionResult(
+            job_id=0,
             counts=job_result_count,
             profiling_metrics=ProfilingMetrics(params=profiling_data),
         )

--- a/src/mqssbench/library/adapters/mqss/pennylane_adapter.py
+++ b/src/mqssbench/library/adapters/mqss/pennylane_adapter.py
@@ -112,7 +112,7 @@ class PennyLaneAdapter(DeviceAdapter):
         else:
             profiling_data = None
         return ExecutionResult(
-            job_id=0,
+            job_id=None,
             counts=job_result_count,
             profiling_metrics=ProfilingMetrics(params=profiling_data),
         )

--- a/src/mqssbench/library/adapters/mqss/qiskit_adapter.py
+++ b/src/mqssbench/library/adapters/mqss/qiskit_adapter.py
@@ -110,7 +110,7 @@ class QiskitAdapter(DeviceAdapter):
             job = backend.run(transpiled_circuit, shots=self._shots)
         else:
             job = backend.run(transpiled_circuit)
-
+        job_id = job.job_id()
         job_result = job.result()
         counts = job_result.get_counts()
         if MQSS_QISKIT_PROFILING_ENABLED:
@@ -118,6 +118,7 @@ class QiskitAdapter(DeviceAdapter):
         else:
             profiling_data = None
         return ExecutionResult(
+            job_id=job_id,
             counts=counts,
             profiling_metrics=ProfilingMetrics(params=profiling_data),
         )

--- a/src/mqssbench/library/benchmarks/quantum_volume.py
+++ b/src/mqssbench/library/benchmarks/quantum_volume.py
@@ -68,14 +68,17 @@ class QuantumVolumeAnalyzer(BenchmarkAnalyzer):
         median_p_heavy = float(np.median(p_heavy_list))
         passed_threshold = bool(median_p_heavy >= 2 / 3)
 
-        if context.output_config.visualization:
+        if context.report_config.analysis.visualization.enabled:
             logger.warning("Visualization for '%s' is not implemented.", context.benchmark_key)
 
-        return AnalysisResult({
-            "trials_p_heavy": p_heavy_list,
-            "median_p_heavy": median_p_heavy,
-            "passed_threshold": passed_threshold,
-        })
+        return AnalysisResult(
+            metrics={
+                "trials_p_heavy": p_heavy_list,
+                "median_p_heavy": median_p_heavy,
+                "passed_threshold": passed_threshold,
+            },
+            artifacts={},
+        )
 
 @BenchmarkRegistry.register_benchmark
 class QuantumVolumeBenchmark(Benchmark):

--- a/src/mqssbench/library/benchmarks/randomized_benchmarking.py
+++ b/src/mqssbench/library/benchmarks/randomized_benchmarking.py
@@ -4,7 +4,7 @@ import matplotlib.pyplot as plt
 import numpy as np
 from scipy.optimize import curve_fit
 
-from ...framework.utils import make_output_path, safe_plot_show
+from ...framework.utils import make_output_filepath
 from ...framework import (
     Benchmark,
     BenchmarkAnalyzer,
@@ -95,14 +95,19 @@ class RandomizedBenchmarkingAnalyzer(BenchmarkAnalyzer):
         dimension = 2**num_qubits
         avg_gate_error = ((dimension - 1) / dimension) * (1 - float(p_decay))
         
-        if context.output_config.visualization:
-            self._plot(lengths, mean_survivals, context)
+        artifacts = {}
+        if context.report_config.analysis.visualization.enabled:
+            plot_filename = self._plot(lengths, mean_survivals, context)
+            artifacts["decay_plot"] = plot_filename
 
-        return AnalysisResult({
-            "mean_survivals": mean_survivals,
-            "decay_p": float(p_decay),
-            "avg_gate_error": float(avg_gate_error),
-        })
+        return AnalysisResult(
+            metrics={
+                "mean_survivals": mean_survivals,
+                "decay_p": float(p_decay),
+                "avg_gate_error": float(avg_gate_error),
+            },
+            artifacts=artifacts,
+        )
 
     def _plot(self, lengths: List[int], survivals: List[float], context: RunContext) -> None:
         backend_name = context.adapter.get_backend_name()
@@ -117,12 +122,10 @@ class RandomizedBenchmarkingAnalyzer(BenchmarkAnalyzer):
         plt.xticks(lengths)
         plt.plot(lengths, survivals, marker="o", linestyle="-")
 
-        if context.output_config.save:
-            bench_name = context.benchmark_key.split("/")[-1]
-            filename = make_output_path(name=bench_name, output_dir=context.output_config.output_dir, is_plot=True)
-            plt.savefig(filename)
+        filename = make_output_filepath(context.benchmark_key, context.run_dir, tag="decay_plot")
+        plt.savefig(filename)
 
-        safe_plot_show()
+        return filename
 
 @BenchmarkRegistry.register_benchmark
 class RandomizedBenchmarkingBenchmark(Benchmark):

--- a/src/mqssbench/runtime/benchmark_manager.py
+++ b/src/mqssbench/runtime/benchmark_manager.py
@@ -38,6 +38,7 @@ class BenchmarkManager:
 
     def _validate_config(self) -> None:
         """Placeholder for future validation."""
+        # implement validation logic (with pydantic, jsonschema or similar)
         return
 
     def dispatch(self) -> List[BenchmarkResult]:

--- a/src/mqssbench/runtime/benchmark_runner.py
+++ b/src/mqssbench/runtime/benchmark_runner.py
@@ -1,15 +1,14 @@
-from typing import Any, Dict
+from typing import Any, Dict, Optional
 import uuid
 import os
 from datetime import datetime
+import dataclasses
 from ..framework import AdapterRegistry
 from ..framework import RunContext, BenchmarkRegistry
 from ..framework.types import ProfilingConfig, BenchmarkResult, ReportConfig, StorageConfig
 from ..framework.utils import show_artifacts
-from ..storage import save_result_json
 from dacite import from_dict, Config
-import dataclasses
-
+from ..storage.storage_registry import get_storage
 class BenchmarkRunner:
     def __init__(self, config: Dict[str, Any]):
         self.config = config
@@ -41,6 +40,10 @@ class BenchmarkRunner:
         report_config = self.config.get("report") or {}
         report_config_obj = from_dict(data_class=ReportConfig, data=report_config, config=Config(strict=True))
 
+        # storage config 
+        storage_config = self.config.get("storage") or {}
+        storage_config_obj = from_dict(data_class=StorageConfig, data=storage_config, config=Config(strict=True))
+
         # create run context
         context = RunContext(
             run_id=run_id,
@@ -55,26 +58,18 @@ class BenchmarkRunner:
         benchmark = BenchmarkRegistry.get_benchmark_instance(benchmark_key, context)
         benchmark_result = benchmark.run()
 
-        # TODO: this is temporarily here until we have a proper storage component
-        # storage config
-        storage_config = self.config.get("storage") or {}
-        if storage_config:
-            storage_config_obj = from_dict(data_class=StorageConfig, data=storage_config, config=Config(strict=True))
-
-            # save result if configured
-            if storage_config_obj.type == "file" and getattr(storage_config_obj.file, "format", None) == "json":
-                saved = save_result_json(context, benchmark_result)
-                if saved:
-                    benchmark_result = dataclasses.replace(
-                        benchmark_result,
-                        storage_location=saved
-                    )
+        # get storage config and store result
+        if storage_config_obj.enabled:
+            saved_location = self._store_result(context, storage_config_obj, benchmark_result)
+            if saved_location is not None:
+                benchmark_result = dataclasses.replace(benchmark_result, storage_location=saved_location)
 
         # show plots if configured
         if report_config_obj.analysis.visualization.enabled and report_config_obj.analysis.visualization.show:
             show_artifacts(benchmark_result.analysis_result.artifacts.values())
             
         return benchmark_result
+
 
     def _resolve_benchmark_key(self) -> str:
         direct_key = self.config.get("benchmark")
@@ -89,3 +84,21 @@ class BenchmarkRunner:
                 "Provide either 'benchmark' with 'origin/source/name' or 'origin', 'source', and 'name' fields."
             )
         return f"{origin}/{source}/{name}"
+
+
+    def _store_result(self, context: RunContext, storage_config_obj: StorageConfig, benchmark_result: BenchmarkResult) -> Optional[str]:
+        if not storage_config_obj.enabled:
+            return None
+        storage_backend = None
+        saved_location: Optional[str] = None
+        try:
+            storage_backend = get_storage(storage_config_obj.type, context=context, config=storage_config_obj)
+            saved_location = storage_backend.save_result(benchmark_result)
+        finally:
+            if storage_backend is not None:
+                try:
+                    storage_backend.close()
+                except Exception:
+                    pass
+
+        return saved_location

--- a/src/mqssbench/runtime/benchmark_runner.py
+++ b/src/mqssbench/runtime/benchmark_runner.py
@@ -1,38 +1,79 @@
 from typing import Any, Dict
-
+import uuid
+import os
+from datetime import datetime
 from ..framework import AdapterRegistry
 from ..framework import RunContext, BenchmarkRegistry
-from ..framework.types import ProfilingConfig, BenchmarkResult, OutputConfig
+from ..framework.types import ProfilingConfig, BenchmarkResult, ReportConfig, StorageConfig
+from ..framework.utils import show_artifacts
+from ..storage import save_result_json
+from dacite import from_dict, Config
+import dataclasses
 
 class BenchmarkRunner:
     def __init__(self, config: Dict[str, Any]):
         self.config = config
 
     def run(self) -> BenchmarkResult:
+        # determine run directory
+        output_dir = self.config.get("output_dir")
+        if not output_dir:
+            raise ValueError("output_dir must be specified in the configuration.")
+        run_id = uuid.uuid4().hex
+        run_tag = f"{datetime.utcnow():%Y%m%dT%H%M%SZ}_{run_id[:8]}"
+        run_dir = os.path.join(output_dir, run_tag)
+
+        # get and validate adapter
         adapter_name = self.config.get("adapter")
         if not adapter_name:
             raise ValueError("The 'adapter' field is mandatory in the benchmark configuration.")
         adapter = AdapterRegistry.get_adapter(adapter_name, self.config)
+
         # get and validate benchmark key
         benchmark_key = self._resolve_benchmark_key()
+
         # validate profiling config
         profiling_config = self.config.get("profiling") or {}
         profiling_config_obj = ProfilingConfig(**profiling_config)
         adapter.validate_profiling_config(profiling_config_obj)
-        # validate output config
-        output_config = self.config.get("output") or {}
-        output_config_obj = OutputConfig(**output_config)
+
+        # report config
+        report_config = self.config.get("report") or {}
+        report_config_obj = from_dict(data_class=ReportConfig, data=report_config, config=Config(strict=True))
+
         # create run context
         context = RunContext(
+            run_id=run_id,
+            run_dir=run_dir,
             adapter=adapter,
             benchmark_key=benchmark_key,
             params=self.config.get("benchmark_params", {}),
-            output_config=output_config_obj,
+            report_config=report_config_obj,
             profiling=profiling_config_obj,
         )
         # get benchmark instance and run
         benchmark = BenchmarkRegistry.get_benchmark_instance(benchmark_key, context)
         benchmark_result = benchmark.run()
+
+        # TODO: this is temporarily here until we have a proper storage component
+        # storage config
+        storage_config = self.config.get("storage") or {}
+        if storage_config:
+            storage_config_obj = from_dict(data_class=StorageConfig, data=storage_config, config=Config(strict=True))
+
+            # save result if configured
+            if storage_config_obj.type == "file" and getattr(storage_config_obj.file, "format", None) == "json":
+                saved = save_result_json(context, benchmark_result)
+                if saved:
+                    benchmark_result = dataclasses.replace(
+                        benchmark_result,
+                        storage_location=saved
+                    )
+
+        # show plots if configured
+        if report_config_obj.analysis.visualization.enabled and report_config_obj.analysis.visualization.show:
+            show_artifacts(benchmark_result.analysis_result.artifacts.values())
+            
         return benchmark_result
 
     def _resolve_benchmark_key(self) -> str:

--- a/src/mqssbench/storage/__init__.py
+++ b/src/mqssbench/storage/__init__.py
@@ -1,0 +1,3 @@
+from .file_storage import save_result_json
+
+__all__ = ["save_result_json"]

--- a/src/mqssbench/storage/__init__.py
+++ b/src/mqssbench/storage/__init__.py
@@ -1,3 +1,3 @@
-from .file_storage import save_result_json
+from .file_storage import FileStorage
 
-__all__ = ["save_result_json"]
+__all__ = ["FileStorage"]

--- a/src/mqssbench/storage/file_storage.py
+++ b/src/mqssbench/storage/file_storage.py
@@ -1,17 +1,42 @@
 import json
-import os
 from datetime import datetime
-from ..framework import RunContext
-from ..framework.types import BenchmarkResult
+from pathlib import Path
+from ..framework.types import BenchmarkResult, RunContext
+from .storage_registry import register_storage
+from .storage_backend import StorageBackend, StorageError
+from ..framework.utils import atomic_write
 
-# TODO: this is temporarily here until we have a proper storage component
-def save_result_json(context: RunContext, result: BenchmarkResult) -> str:
-    run_dir = context.run_dir
-    os.makedirs(run_dir, exist_ok=True)
+@register_storage("file")
+class FileStorage(StorageBackend):
+    def initialize(self):
+        self.results_path = Path(self.context.run_dir) / "results.json"
+        self.results_path.parent.mkdir(parents=True, exist_ok=True)
+
+    def save_result(self, result: BenchmarkResult) -> str:
+        try:
+            if self.config.file.format != "json":
+                raise StorageError(f"Unsupported format: {self.config.file.format}")
+
+            payload = serialize_result_json(self.context, result)
+
+            atomic_write(
+                self.results_path,
+                lambda f: json.dump(payload, f, indent=2, ensure_ascii=False)
+            )
+        except Exception as e:
+            raise StorageError(e)
+
+        return str(self.results_path)
+
+    def close(self):
+        return None
+
+
+def serialize_result_json(context: RunContext, result: BenchmarkResult) -> dict:
     now = datetime.utcnow().isoformat() + "Z"
 
-    payload = {
-        "schema_version": 0.1, # use version 1.0 when becoming stable
+    return {
+        "schema_version": 0.1,
         "timestamp_utc": now,
         "run_id": context.run_id,
         "benchmark_key": result.benchmark_key,
@@ -21,27 +46,17 @@ def save_result_json(context: RunContext, result: BenchmarkResult) -> str:
         },
         "execution_results": [
             {
-                "job_id": getattr(er, "job_id", None),
+                "job_id": er.job_id,
                 "counts": er.counts,
-                # TODO: write this
-                "profiling_metrics": getattr(er.profiling_metrics, "params", None) if getattr(er, "profiling_metrics", None) else None,
-                #"metadata": er.metadata,
-            } for er in result.execution_results
+                "profiling_metrics": (
+                    er.profiling_metrics.params
+                    if er.profiling_metrics else None
+                ),
+            }
+            for er in result.execution_results
         ],
         "analysis": {
-            "metrics": getattr(result.analysis_result, "metrics", None),
-            "artifacts": getattr(result.analysis_result, "artifacts", None),
+            "metrics": result.analysis_result.metrics,
+            "artifacts": result.analysis_result.artifacts,
         } if result.analysis_result else None,
     }
-
-    # Atomic write to avoid corrupted result.json on failure
-    tmp = os.path.join(run_dir, ".result.json.tmp")
-    final = os.path.join(run_dir, "result.json")
-    with open(tmp, "w", encoding="utf-8") as f:
-        json.dump(payload, f, indent=2, ensure_ascii=False)
-    os.replace(tmp, final)
-
-    return final
-
-
-

--- a/src/mqssbench/storage/file_storage.py
+++ b/src/mqssbench/storage/file_storage.py
@@ -1,0 +1,47 @@
+import json
+import os
+from datetime import datetime
+from ..framework import RunContext
+from ..framework.types import BenchmarkResult
+
+# TODO: this is temporarily here until we have a proper storage component
+def save_result_json(context: RunContext, result: BenchmarkResult) -> str:
+    run_dir = context.run_dir
+    os.makedirs(run_dir, exist_ok=True)
+    now = datetime.utcnow().isoformat() + "Z"
+
+    payload = {
+        "schema_version": 0.1, # use version 1.0 when becoming stable
+        "timestamp_utc": now,
+        "run_id": context.run_id,
+        "benchmark_key": result.benchmark_key,
+        "benchmark_params": result.params,
+        "adapter": {
+            "backend": context.adapter.get_backend_name()
+        },
+        "execution_results": [
+            {
+                "job_id": getattr(er, "job_id", None),
+                "counts": er.counts,
+                # TODO: write this
+                "profiling_metrics": getattr(er.profiling_metrics, "params", None) if getattr(er, "profiling_metrics", None) else None,
+                #"metadata": er.metadata,
+            } for er in result.execution_results
+        ],
+        "analysis": {
+            "metrics": getattr(result.analysis_result, "metrics", None),
+            "artifacts": getattr(result.analysis_result, "artifacts", None),
+        } if result.analysis_result else None,
+    }
+
+    # Atomic write to avoid corrupted result.json on failure
+    tmp = os.path.join(run_dir, ".result.json.tmp")
+    final = os.path.join(run_dir, "result.json")
+    with open(tmp, "w", encoding="utf-8") as f:
+        json.dump(payload, f, indent=2, ensure_ascii=False)
+    os.replace(tmp, final)
+
+    return final
+
+
+

--- a/src/mqssbench/storage/storage_backend.py
+++ b/src/mqssbench/storage/storage_backend.py
@@ -1,0 +1,31 @@
+from __future__ import annotations
+from abc import ABC, abstractmethod
+from mqssbench.framework.types import BenchmarkResult, RunContext, StorageConfig
+
+class StorageError(Exception):
+    pass
+
+class StorageBackend(ABC):
+    """Abstract storage backend."""
+
+    def __init__(self, context: RunContext, config: StorageConfig):
+        self.context = context
+        self.config = config
+
+    @abstractmethod
+    def initialize(self) -> None:
+        """Prepare storage (create paths, open DB, migrations)."""
+        pass
+
+    @abstractmethod
+    def save_result(self, result: BenchmarkResult) -> str:
+        """
+        Persist the structured result (and return the path or URI to file, DB, etc.).
+        Must be atomic: either succeed fully or raise StorageError.
+        """
+        pass
+
+    @abstractmethod
+    def close(self) -> None:
+        """Cleanup resources (close DB connections)."""
+        pass

--- a/src/mqssbench/storage/storage_registry.py
+++ b/src/mqssbench/storage/storage_registry.py
@@ -1,0 +1,20 @@
+from typing import Type
+from .storage_backend import StorageBackend
+from ..framework.types import StorageConfig, RunContext
+
+_STORAGE_REGISTRY: dict[str, Type[StorageBackend]] = {}
+
+def register_storage(name: str):
+    def _decor(cls):
+        _STORAGE_REGISTRY[name] = cls
+        return cls
+    return _decor
+
+def get_storage(name: str, context: RunContext, config: StorageConfig) -> StorageBackend:
+    try:
+        cls = _STORAGE_REGISTRY[name]
+    except KeyError:
+        raise ValueError(f"Unknown storage backend {name}")
+    inst = cls(context=context, config=config)
+    inst.initialize()
+    return inst

--- a/test/framework/test_benchmark_registry.py
+++ b/test/framework/test_benchmark_registry.py
@@ -7,6 +7,7 @@ tests. As the API stabilizes, it will be expanded with comprehensive coverage.
 
 import threading
 import pytest
+import tempfile
 
 from mqssbench.framework.benchmark_registry import BenchmarkRegistry
 from mqssbench.framework.adapter_registry import AdapterRegistry
@@ -17,17 +18,28 @@ from mqssbench.framework.benchmark_executor import BenchmarkExecutor, DefaultBen
 from mqssbench.framework.benchmark_analyzer import BenchmarkAnalyzer, DefaultAnalyzer
 from mqssbench.framework.types import (
     RunContext,
-    OutputConfig,
+    ReportConfig,
     ExecutionResult,
     ProfilingMetrics,
     CircuitSpec,
     BenchmarkCategory,
+    AnalysisConfig,
 )
 
 
 # -----------------------------------------------------------------------------
 # Fixtures
 # -----------------------------------------------------------------------------
+
+@pytest.fixture
+def temp_run_dir():
+    with tempfile.TemporaryDirectory() as tmp:
+        yield tmp
+
+@pytest.fixture
+def temp_output_dir():
+    with tempfile.TemporaryDirectory() as tmp:
+        yield tmp
 
 @pytest.fixture(autouse=True)
 def isolate_registries():
@@ -52,9 +64,11 @@ def make_minimal_context(adapter_name: str, benchmark_key: str) -> RunContext:
             return "dummy"
 
     return RunContext(
+        run_id="test_run_id",
+        run_dir=temp_run_dir,
         adapter=DummyAdapter(),
         benchmark_key=benchmark_key,
-        output_config=OutputConfig(),  # use defaults
+        report_config=ReportConfig(),  # use defaults
     )
 
 
@@ -255,6 +269,7 @@ def test_end_to_end_benchmark_run_via_registry():
             self._calls.append({"built": built, "num_qubits": num_qubits})
 
             return ExecutionResult(
+                job_id="dummy_job_id",
                 counts={"0": 10, "1": 5},
                 profiling_metrics=ProfilingMetrics(params={"dummy_metric": 42}),
                 metadata={},  # DefaultBenchmarkExecutor will copy spec.metadata into ExecutionResult.metadata
@@ -291,10 +306,12 @@ def test_end_to_end_benchmark_run_via_registry():
     adapter_instance = AdapterRegistry.get_adapter("dummy_adapter", {})
 
     ctx = RunContext(
+        run_id="test_run_id",
+        run_dir=temp_run_dir,
         adapter=adapter_instance,
         benchmark_key=key,
         params={},  # no params required
-        output_config=OutputConfig(analysis=True, visualization=False, save=False),
+        report_config=ReportConfig(analysis=AnalysisConfig(enabled=True)),
     )
 
     bench_inst = BenchmarkRegistry.get_benchmark_instance(key, ctx)
@@ -311,9 +328,9 @@ def test_end_to_end_benchmark_run_via_registry():
     assert ex0.metadata.get("num_qubits") == 1
 
     assert result.analysis_result is not None
-    assert "total_shots" in result.analysis_result.results
-    assert result.analysis_result.results["total_shots"] == 15
-    probs = result.analysis_result.results["probabilities"]
+    assert "total_shots" in result.analysis_result.metrics
+    assert result.analysis_result.metrics["total_shots"] == 15
+    probs = result.analysis_result.metrics["probabilities"]
     assert pytest.approx(probs["0"]) == 10 / 15
     assert pytest.approx(probs["1"]) == 5 / 15
 
@@ -322,7 +339,7 @@ def test_end_to_end_benchmark_run_via_registry():
 # BenchmarkRunner integration: use a config dict and run via BenchmarkRunner
 # -----------------------------------------------------------------------------
 
-def test_benchmark_runner_integration():
+def test_benchmark_runner_integration(temp_output_dir):
     """
     Validate BenchmarkRunner.run works with a real config dict.
     Registers dummy adapter and benchmark, builds config, calls runner.run.
@@ -350,6 +367,7 @@ def test_benchmark_runner_integration():
 
         def execute_circuit(self, context: RunContext, circuit, num_qubits=None, transpile_mode=True) -> ExecutionResult:
             return ExecutionResult(
+                job_id="dummy_job_id",
                 counts={"0": 2, "1": 3},
                 profiling_metrics=ProfilingMetrics(params={"dummy": 1}),
                 metadata={},
@@ -388,7 +406,12 @@ def test_benchmark_runner_integration():
         "benchmark_params": {},
         "adapter": "dummy_adapter",
         "profiling": {},
-        "output": {"analysis": True, "visualization": False, "save": False},
+        "output_dir": temp_output_dir,  # injected temp dir for the test
+        "report": {"analysis": {"enabled": True}},
+        # "storage": {
+        #     "type": "file",
+        #     "file": {"format": "json"},
+        # },
     }
 
     runner = BenchmarkRunner(config)
@@ -402,7 +425,7 @@ def test_benchmark_runner_integration():
     assert ex.counts["0"] == 2
     assert ex.counts["1"] == 3
     assert result.analysis_result is not None
-    assert result.analysis_result.results["total_shots"] == 5
+    assert result.analysis_result.metrics["total_shots"] == 5
 
 
 # -----------------------------------------------------------------------------

--- a/uv.lock
+++ b/uv.lock
@@ -410,6 +410,15 @@ wheels = [
 ]
 
 [[package]]
+name = "dacite"
+version = "1.9.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/55/a0/7ca79796e799a3e782045d29bf052b5cde7439a2bbb17f15ff44f7aacc63/dacite-1.9.2.tar.gz", hash = "sha256:6ccc3b299727c7aa17582f0021f6ae14d5de47c7227932c47fec4cdfefd26f09", size = 22420 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/94/35/386550fd60316d1e37eccdda609b074113298f23cef5bddb2049823fe666/dacite-1.9.2-py3-none-any.whl", hash = "sha256:053f7c3f5128ca2e9aceb66892b1a3c8936d02c686e707bee96e19deef4bc4a0", size = 16600 },
+]
+
+[[package]]
 name = "diastatic-malt"
 version = "2.15.2"
 source = { registry = "https://pypi.org/simple" }
@@ -724,6 +733,7 @@ version = "0.1.0"
 source = { editable = "." }
 dependencies = [
     { name = "colorama" },
+    { name = "dacite" },
     { name = "mqss-pennylane-adapter" },
     { name = "mqss-qiskit" },
     { name = "mqt-bench" },
@@ -754,6 +764,7 @@ dev = [
 [package.metadata]
 requires-dist = [
     { name = "colorama", specifier = ">=0.4.6" },
+    { name = "dacite", specifier = ">=1.9.2" },
     { name = "mqss-pennylane-adapter", specifier = "==1.1.2" },
     { name = "mqss-qiskit", specifier = ">=0.2.0" },
     { name = "mqt-bench", specifier = ">=2.0.0" },


### PR DESCRIPTION
This PR introduces support for benchmark storage with a pluggable storage backend and registry, and implements FileStorage.

Key changes:
- Add and integrate required structure, configs, and flow for benchmark storage
- Add storage backend interface and registry for pluggable backends
- Add `FileStorage` backend for JSON format
- Integrate storage backend system into `BenchmarkRunner`
- Store analysis results with added metrics and artifacts fields
- Make plotting optional via config and non-blocking using the system default viewer
- Introduce a unique `run_id` for each benchmark run and include it in reports
- Add `job_id` to `ExecutionResult` and implement it in the MQSS Qiskit adapter
- Update examples, tests, and documentation

Note: This is an initial implementation of the benchmark storage system.

closes #25 