### PR TITLE
Add pytest coverage reporting to CI pipeline

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,11 +31,18 @@ jobs:
 
         - name: List the project dependencies
           run: uv pip list
+
         - name: Install Ruff
           run: uv pip install ruff
 
         - name: Run Ruff Linter
           run: uv run ruff check .
 
-        - name: Run Pytest
-          run: uv run pytest -s --maxfail=1 --disable-warnings
+        - name: Run Pytest with coverage
+          run: uv run pytest -s --maxfail=1 --disable-warnings --cov=src --cov-report=term-missing --cov-report=xml
+
+        - name: Upload coverage report
+          uses: actions/upload-artifact@v4
+          with:
+            name: coverage-xml
+            path: coverage.xml

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,6 +16,7 @@ dependencies = [
     "pyyaml>=6.0.3",
     "colorama>=0.4.6",
     "dacite>=1.9.2",
+    "pytest-cov>=7.0.0",
 ]
 
 # for PyPy

--- a/uv.lock
+++ b/uv.lock
@@ -729,7 +729,7 @@ wheels = [
 
 [[package]]
 name = "mqss-benchmarking-framework"
-version = "0.1.0"
+version = "1.0.0"
 source = { editable = "." }
 dependencies = [
     { name = "colorama" },
@@ -739,6 +739,7 @@ dependencies = [
     { name = "mqt-bench" },
     { name = "numpy" },
     { name = "pennylane" },
+    { name = "pytest-cov" },
     { name = "pyyaml" },
     { name = "qiskit-aer" },
     { name = "qiskit-experiments" },
@@ -772,6 +773,7 @@ requires-dist = [
     { name = "pennylane", specifier = ">=0.41.1" },
     { name = "pylint", marker = "extra == 'dev'" },
     { name = "pytest", marker = "extra == 'dev'" },
+    { name = "pytest-cov", specifier = ">=7.0.0" },
     { name = "pytest-cov", marker = "extra == 'dev'" },
     { name = "pyyaml", specifier = ">=6.0.3" },
     { name = "qiskit-aer", specifier = ">=0.13.3" },
@@ -1428,6 +1430,10 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/1c/ca/a1cd95daf75d09d2dc1744cde95d5d18fed61a0e4922788fb916a7cd8152/qiskit_aer-0.17.2-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:2749e6027f67e1f6b9d328d2dda2d4bf926aebd3653edc62e94c45d8237294d8", size = 12376191 },
     { url = "https://files.pythonhosted.org/packages/d6/69/e2f979e2fca054b0092fc52c46da050298513b9b03531305bc3f340c7669/qiskit_aer-0.17.2-cp313-cp313-win32.whl", hash = "sha256:c3ffd40a64bfcf8a6d10cbfdca8734d49ec57502fd70dc63aae9ed3819249dd6", size = 6922275 },
     { url = "https://files.pythonhosted.org/packages/ae/91/195cb69d3af4359544939378879093764bd35d8abd7ac0de840bb5477d27/qiskit_aer-0.17.2-cp313-cp313-win_amd64.whl", hash = "sha256:b38c5dfdc6cb2bacac78a47b0df8247123051564007fdecedb8ffbd4256f0f09", size = 9563116 },
+    { url = "https://files.pythonhosted.org/packages/2c/1b/b0516cd3d0e83ebe30e8d04d2a156dac883fd8ac4521deb12de582b2fc78/qiskit_aer-0.17.2-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:c282b9b65f2b011d740e76b0ab44201c70d8d48894ddc12e22442acbb81cc7eb", size = 2393891 },
+    { url = "https://files.pythonhosted.org/packages/65/5b/c8bf7942ca12d50c4c8c9fde82f25ebcd6198b98f66c51616a9225d541bc/qiskit_aer-0.17.2-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:193de16895ee989a5259331d0f1b1dcad606d506e5e831683ff165e82851a7ac", size = 2117650 },
+    { url = "https://files.pythonhosted.org/packages/ff/27/f7b518f0928792e454ca9018d712769abf96033902e41bb3b648ff14833b/qiskit_aer-0.17.2-cp314-cp314-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:b84564d563fb06adb454f3528dcc343be327c30cbd5f9f40aec7efd21d241e55", size = 14160447 },
+    { url = "https://files.pythonhosted.org/packages/f6/c1/59fe9c10e8d53533990ccf1bdf87ac74f77ced57d63a233f759df02bd361/qiskit_aer-0.17.2-cp314-cp314-win_amd64.whl", hash = "sha256:5d7b22dd945df4c69d57e966efb549cf9186055e5f32c649a91b7dd1eb133f07", size = 9697912 },
 ]
 
 [[package]]


### PR DESCRIPTION
Add pytest coverage reporting to CI pipeline

Changes:
- Added `pytest-cov` dependency
- Updated CI test step to run coverage with pytest
- Uploads `coverage.xml` as a CI artifact for inspection anf use
- Coverage output shown in CI logs
 
Future tasks:
- Consider integrating Codecov to upload coverage reports
- Optionally enforce a minimum coverage threshold in CI
- Add a coverage badge to the README once Codecov is configured

Closes #28 