### PR TITLE
Add support for adapter-specific parameters

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -33,3 +33,4 @@ results/
 
 # System files
 .DS_Store
+.coverage

--- a/README.md
+++ b/README.md
@@ -117,14 +117,10 @@ benchmark_params:
 
 # Adapter configuration
 adapter: <ADAPTER_NAME>
-backend: <BACKEND>
-
-# Credentials for the adapter or backend
-credentials:
-  <CREDENTIAL_KEY>: <CREDENTIAL_VALUE>
-
-# Number of measurement shots
-shots: <NUM_SHOTS>
+adapter_params:
+  <ADAPTER_PARAM_1>: <VALUE_1>
+  <ADAPTER_PARAM_2>: <VALUE_2>
+  <ADAPTER_PARAM_3>: <VALUE_3>
 
 # output directory
 output_dir: <PATH>
@@ -170,12 +166,13 @@ benchmark_params:
   num_sequences: 2
 
 adapter: mqss_qiskit
-backend: QExa20
-
-credentials:
-  mqss_token: ""
-
-shots: 1000
+adapter_params:
+  backend: QExa20
+  backend_params:
+    queued: true
+  credentials:
+    mqss_token: ""
+  shots: 1000
 
 output_dir: "./results"
 
@@ -209,10 +206,11 @@ Example of a multi benchmark config:
     lengths: [2, 4, 8]
     num_sequences: 2
   adapter: mqss_qiskit
-  backend: QExa20
-  credentials:
-    mqss_token: ""
-  shots: 200
+  adapter_params:
+    backend: QExa20
+    credentials:
+      mqss_token: ""
+    shots: 200
   output_dir: "./results"
   storage:
     enabled: true
@@ -226,10 +224,11 @@ Example of a multi benchmark config:
     depth: 3
     trials: 2
   adapter: mqss_qiskit
-  backend: QExa20
-  credentials:
-    mqss_token: ""
-  shots: 200
+  adapter_params:
+    backend: QExa20
+    credentials:
+      mqss_token: ""
+    shots: 200
   output_dir: "./results"
   storage:
     enabled: true
@@ -257,15 +256,15 @@ config = {
   },
 
   "adapter": "mqss_qiskit",
-  "backend": "QExa20",
-
-  "credentials": {
-    "mqss_token": ""
+  "adapter_params": {
+    "backend": "QExa20",
+    "credentials": {
+      "mqss_token": ""
+    },
+    "shots": 1000
   },
 
-  "shots": 1000,
-
-  "output_dir": "./results"
+  "output_dir": "./results",
 
   "report": {
     "analysis": {

--- a/examples/config_mqt_vqe.yaml
+++ b/examples/config_mqt_vqe.yaml
@@ -5,12 +5,11 @@ benchmark_params:
   level: ALG
 
 adapter: mqss_qiskit
-backend: QExa20
-
-credentials:
-  mqss_token: ""
-
-shots: 200
+adapter_params:
+  backend: QExa20
+  credentials:
+    mqss_token: ""
+  shots: 200
 
 output_dir: "./results"
 

--- a/examples/config_multi.yaml
+++ b/examples/config_multi.yaml
@@ -6,10 +6,11 @@
     lengths: [2, 4, 8]
     num_sequences: 2
   adapter: mqss_qiskit
-  backend: QExa20
-  credentials:
-    mqss_token: ""
-  shots: 200
+  adapter_params:
+    backend: QExa20
+    credentials:
+      mqss_token: ""
+    shots: 200
   output_dir: "./results"
   storage:
     enabled: true
@@ -23,10 +24,11 @@
     depth: 3
     trials: 2
   adapter: mqss_qiskit
-  backend: QExa20
-  credentials:
-    mqss_token: ""
-  shots: 200
+  adapter_params:
+    backend: QExa20
+    credentials:
+      mqss_token: ""
+    shots: 200
   output_dir: "./results"
   storage:
     enabled: true
@@ -39,10 +41,11 @@
     num_qubits: 2
     level: ALG
   adapter: mqss_qiskit
-  backend: QExa20
-  credentials:
-    mqss_token: ""
-  shots: 200
+  adapter_params:
+    backend: QExa20
+    credentials:
+      mqss_token: ""
+    shots: 200
   output_dir: "./results"
   storage:
     enabled: true

--- a/examples/config_qaoa.yaml
+++ b/examples/config_qaoa.yaml
@@ -10,12 +10,11 @@ benchmark_params: # benchamark specific params
   parameters: [0.5, 0.5, 0.5, 0.5]
   
 adapter: mqss_qiskit
-backend: QExa20
-
-credentials:
-  mqss_token: ""
-
-shots: 2048
+adapter_params:
+  backend: QExa20
+  credentials:
+    mqss_token: ""
+  shots: 2048
 
 output_dir: "./results"
 

--- a/examples/config_qaoa_simulator.yaml
+++ b/examples/config_qaoa_simulator.yaml
@@ -11,11 +11,10 @@ benchmark_params: # benchamark specific params
   
 adapter: qiskit_simulator
 
-
-credentials:
-  mqss_token: ""
-
-shots: 1024
+adapter_params:
+  credentials:
+    mqss_token: ""
+  shots: 1024
 
 output_dir: "./results"
 

--- a/examples/config_qv.yaml
+++ b/examples/config_qv.yaml
@@ -6,12 +6,14 @@ benchmark_params:
   trials: 2
 
 adapter: mqss_qiskit
-backend: QExa20
-
-credentials:
-  mqss_token: ""
-
-shots: 200
+adapter_params:
+  backend: QExa20
+  backend_params:
+    queued: true
+    no_modify: true
+  credentials:
+    mqss_token: ""
+  shots: 200
 
 output_dir: "./results"
 

--- a/examples/config_rb.yaml
+++ b/examples/config_rb.yaml
@@ -6,12 +6,11 @@ benchmark_params: # benchamark specific params
   num_sequences: 10
 
 adapter: mqss_qiskit
-backend: QExa20
-
-credentials:
-  mqss_token: ""
-
-shots: 1024
+adapter_params:
+  backend: QExa20
+  credentials:
+    mqss_token: ""
+  shots: 1024
 
 output_dir: "./results"
 

--- a/examples/config_rb_simulator.yaml
+++ b/examples/config_rb_simulator.yaml
@@ -6,12 +6,10 @@ benchmark_params: # benchamark specific params
   num_sequences: 20
 
 adapter: qiskit_simulator
-#backend: QExa20 
-
-credentials:
-  mqss_token: ""
-
-shots: 1024
+adapter_params:
+  credentials:
+    mqss_token: ""
+  shots: 1024
 
 output_dir: "./results"
 

--- a/examples/custom_benchmark.py
+++ b/examples/custom_benchmark.py
@@ -76,9 +76,11 @@ if __name__ == "__main__":
         "benchmark": "user/my_examples/custom_benchmark",
         "benchmark_params": {"num_qubits": 1, "depth": 3},
         "adapter": "mqss_qiskit",
-        "backend": "QExa20",
-        "credentials": {"mqss_token": ""},
-        "shots": 200,
+        "adapter_params": {
+            "backend": "QExa20",
+            "credentials": {"mqss_token": ""},
+            "shots": 200,
+        },
         "output_dir": "./results",
     }
 

--- a/examples/run_example.py
+++ b/examples/run_example.py
@@ -14,9 +14,11 @@ config = {
         "trials": 2
     },
     "adapter": "mqss_qiskit",
-    "backend": "QExa20",
-    "credentials": {"mqss_token": ""},
-    "shots": 200,
+    "adapter_params": {
+        "backend": "QExa20",
+        "credentials": {"mqss_token": ""},
+        "shots": 200,
+    },
     "output_dir": "./results",
     "storage": {
         "enabled": True,

--- a/src/mqssbench/framework/adapter.py
+++ b/src/mqssbench/framework/adapter.py
@@ -19,8 +19,8 @@ class DeviceAdapter(ABC):
                 f"{cls.__name__}: missing or invalid 'name' class attribute."
             )
 
-    def __init__(self, config):
-        """Initialize the adapter with the given configuration."""
+    def __init__(self, adapter_params):
+        """Initialize the adapter with the given adapter parameters."""
         pass
 
     @abstractmethod

--- a/src/mqssbench/framework/adapter_registry.py
+++ b/src/mqssbench/framework/adapter_registry.py
@@ -49,12 +49,12 @@ class AdapterRegistry:
 
         return adapter_cls
 
-    def _get(self, adapter_name: str, config: Dict[str, Any]) -> DeviceAdapter:
+    def _get(self, adapter_name: str, adapter_params: Dict[str, Any]) -> DeviceAdapter:
         """Instantiate and return an adapter by adapter name."""
         self._validate_adapter_name(adapter_name)
         try:
             adapter_cls = self._registry[adapter_name]
-            return adapter_cls(config)  # instantiate with config
+            return adapter_cls(adapter_params)  # instantiate with adapter parameters
         except KeyError:
             available = ", ".join(sorted(self._registry.keys())) or "none"
             raise ValueError(f"No adapter registered for adapter name '{adapter_name}'. available: {available}")
@@ -78,9 +78,9 @@ class AdapterRegistry:
         return cls()._register(adapter_cls)
 
     @classmethod
-    def get_adapter(cls, adapter_name: str, config: Dict[str, Any]) -> DeviceAdapter:
+    def get_adapter(cls, adapter_name: str, adapter_params: Dict[str, Any]) -> DeviceAdapter:
         """Get an adapter instance by adapter name."""
-        return cls()._get(adapter_name, config)
+        return cls()._get(adapter_name, adapter_params)
 
     @classmethod
     def list_adapters(cls) -> List[str]:

--- a/src/mqssbench/library/adapters/mqss/pennylane_adapter.py
+++ b/src/mqssbench/library/adapters/mqss/pennylane_adapter.py
@@ -93,7 +93,7 @@ class PennyLaneAdapter(DeviceAdapter):
         # TODO: for now implement transpile_mode, later consider exploring alternatives to transpilation here
         
         print(f"Running circuit on backend {self._backend_name} ...")
-        print(circuit)
+        logger.info("circuit\n%s", circuit)
 
         # Build qnode
         if callable(circuit):

--- a/src/mqssbench/library/adapters/mqss/pennylane_adapter.py
+++ b/src/mqssbench/library/adapters/mqss/pennylane_adapter.py
@@ -15,19 +15,19 @@ MQSS_PENNYLANE_PROFILING_ENABLED = False
 class PennyLaneAdapter(DeviceAdapter):
     name = "mqss_pennylane"
 
-    def __init__(self, config):
-        self.config = config
+    def __init__(self, adapter_params):
+        self.adapter_params = adapter_params
         
-        if not isinstance(config, dict):
-            raise TypeError("config must be a dict")
+        if not isinstance(adapter_params, dict):
+            raise TypeError("adapter_params must be a dict")
         
-        self._backend_name = str(config.get("backend", "")).strip()
+        self._backend_name = str(adapter_params.get("backend", "")).strip()
         if self._backend_name is None or self._backend_name == "":
                 self._backend_name = (MQSS_BACKEND).strip()
         if not self._backend_name:
             raise ValueError("Missing required config: backend or MQSS_BACKEND")
         
-        credentials = config.get("credentials") or {}
+        credentials = adapter_params.get("credentials") or {}
         self._token = str(credentials.get("mqss_token") if isinstance(credentials, dict) else None).strip()
         if self._token is None or self._token == "":
             self._token = (MQSS_TOKEN).strip()
@@ -36,7 +36,7 @@ class PennyLaneAdapter(DeviceAdapter):
                 "Missing required config: credentials.mqss_token or MQSS_TOKEN"
             )
         
-        self._shots = int(config["shots"]) if config.get("shots") is not None else None
+        self._shots = int(adapter_params["shots"]) if adapter_params.get("shots") is not None else None
         # Device will be created lazily in _get_device() when needed
 
     def _get_device(self, num_qubits):

--- a/src/mqssbench/library/adapters/mqss/qiskit_adapter.py
+++ b/src/mqssbench/library/adapters/mqss/qiskit_adapter.py
@@ -22,19 +22,19 @@ MQSS_QISKIT_PROFILING_ENABLED = True
 class QiskitAdapter(DeviceAdapter):
     name = "mqss_qiskit"
 
-    def __init__(self, config):
-        self.config = config
+    def __init__(self, adapter_params):
+        self.adapter_params = adapter_params
 
-        if not isinstance(config, dict):
-            raise TypeError("config must be a dict")
+        if not isinstance(adapter_params, dict):
+            raise TypeError("adapter_params must be a dict")
 
-        self._backend_name = str(config.get("backend", "")).strip()
+        self._backend_name = str(adapter_params.get("backend", "")).strip()
         if self._backend_name is None or self._backend_name == "":
             self._backend_name = (MQSS_BACKEND).strip()
         if not self._backend_name:
             raise ValueError("Missing required config: backend or MQSS_BACKEND")
 
-        credentials = config.get("credentials") or {}
+        credentials = adapter_params.get("credentials") or {}
         self._token = str(
             credentials.get("mqss_token") if isinstance(credentials, dict) else None
         ).strip()
@@ -45,7 +45,11 @@ class QiskitAdapter(DeviceAdapter):
                 "Missing required config: credentials.mqss_token or MQSS_TOKEN"
             )
 
-        self._shots = int(config["shots"]) if config.get("shots") is not None else None
+        self._shots = int(adapter_params.get("shots")) if adapter_params.get("shots") is not None else None
+        backend_params = adapter_params.get("backend_params") or {}
+        if not isinstance(backend_params, dict):
+            raise TypeError("adapter_params.backend_params must be a dict")
+        self._backend_params = dict(backend_params)
         # Adapter and backend will be created lazily in _get_backend()
 
     def _get_backend(self):
@@ -106,22 +110,21 @@ class QiskitAdapter(DeviceAdapter):
         if not isinstance(built_circuit, QuantumCircuit):
             raise TypeError("circuit must be a Qiskit QuantumCircuit")
 
-        # TODO: consider exploring alternatives to transpilation here
-        # Transpile to basic gates to avoid unsupported custom instructions errors (a conservative basis set compatible with most backends)
+        backend = self._get_backend()
+        # Transpile for this backend so the basis matches what the device supports
         if transpile_mode is True:
             transpiled_circuit = transpile(
                 built_circuit,
-                basis_gates=["u", "cx"],
+                backend=backend,
                 optimization_level=0,
             )
         else:
             transpiled_circuit = built_circuit
-
-        backend = self._get_backend()
+        backend_params = dict(self._backend_params)
         if self._shots is not None:
-            job = backend.run(transpiled_circuit, shots=self._shots)
+            job = backend.run(transpiled_circuit, shots=self._shots, **backend_params)
         else:
-            job = backend.run(transpiled_circuit)
+            job = backend.run(transpiled_circuit, **backend_params)
         job_id = job.job_id()
         job_result = job.result()
         counts = job_result.get_counts()

--- a/src/mqssbench/library/adapters/mqss/qiskit_adapter.py
+++ b/src/mqssbench/library/adapters/mqss/qiskit_adapter.py
@@ -105,7 +105,7 @@ class QiskitAdapter(DeviceAdapter):
             built_circuit = circuit
 
         print(f"Running circuit on backend {self._backend_name} ...")
-        print("circuit", built_circuit)
+        logger.info("circuit\n%s", built_circuit)
 
         if not isinstance(built_circuit, QuantumCircuit):
             raise TypeError("circuit must be a Qiskit QuantumCircuit")

--- a/src/mqssbench/library/adapters/mqss/qiskit_simulator_adapter.py
+++ b/src/mqssbench/library/adapters/mqss/qiskit_simulator_adapter.py
@@ -18,13 +18,17 @@ logger = logging.getLogger(__name__)
 class QiskitSimulatorAdapter(DeviceAdapter):
     name = "qiskit_simulator"
 
-    def __init__(self, config):
-        self.config = config
+    def __init__(self, adapter_params):
+        self.adapter_params = adapter_params
         self._backend_name = "qiskit_simulator"
-        if not isinstance(config, dict):
-            raise TypeError("config must be a dict")
+        if not isinstance(adapter_params, dict):
+            raise TypeError("adapter_params must be a dict")
 
-        self._shots = int(config["shots"]) if config.get("shots") is not None else 1024
+        self._shots = int(adapter_params["shots"]) if adapter_params.get("shots") is not None else 1024
+        backend_params = adapter_params.get("backend_params") or {}
+        if not isinstance(backend_params, dict):
+            raise TypeError("adapter_params.backend_params must be a dict")
+        self._backend_params = dict(backend_params)
         # Adapter and backend will be created lazily in _get_backend()
 
     def _get_backend(self):
@@ -76,10 +80,11 @@ class QiskitSimulatorAdapter(DeviceAdapter):
             raise TypeError("circuit must be a Qiskit QuantumCircuit")
 
         backend = self._get_backend()
+        backend_params = dict(self._backend_params)
         if self._shots is not None:
-            job = backend.run([transpiled_circuit], shots=self._shots)
+            job = backend.run([transpiled_circuit], shots=self._shots, **backend_params)
         else:
-            job = backend.run([transpiled_circuit])
+            job = backend.run([transpiled_circuit], **backend_params)
 
         result = job.result()
         try:

--- a/src/mqssbench/runtime/benchmark_runner.py
+++ b/src/mqssbench/runtime/benchmark_runner.py
@@ -26,7 +26,9 @@ class BenchmarkRunner:
         adapter_name = self.config.get("adapter")
         if not adapter_name:
             raise ValueError("The 'adapter' field is mandatory in the benchmark configuration.")
-        adapter = AdapterRegistry.get_adapter(adapter_name, self.config)
+        adapter = AdapterRegistry.get_adapter(
+            adapter_name, self.config.get("adapter_params", {})
+        )
 
         # get and validate benchmark key
         benchmark_key = self._resolve_benchmark_key()

--- a/test/framework/test_benchmark_registry.py
+++ b/test/framework/test_benchmark_registry.py
@@ -245,12 +245,12 @@ def test_end_to_end_benchmark_run_via_registry():
     class DummyAdapter(DeviceAdapter):
         name = "dummy_adapter"
 
-        def __init__(self, config):
-            if config is None:
-                config = {}
-            if not isinstance(config, dict):
-                raise TypeError("config must be a dict")
-            self.config = config
+        def __init__(self, adapter_params):
+            if adapter_params is None:
+                adapter_params = {}
+            if not isinstance(adapter_params, dict):
+                raise TypeError("adapter_params must be a dict")
+            self.adapter_params = adapter_params
             self._calls = []
 
         @classmethod
@@ -351,12 +351,12 @@ def test_benchmark_runner_integration(temp_output_dir):
     class DummyAdapter(DeviceAdapter):
         name = "dummy_adapter"
 
-        def __init__(self, config):
-            if config is None:
-                config = {}
-            if not isinstance(config, dict):
-                raise TypeError("config must be a dict")
-            self.config = config
+        def __init__(self, adapter_params):
+            if adapter_params is None:
+                adapter_params = {}
+            if not isinstance(adapter_params, dict):
+                raise TypeError("adapter_params must be a dict")
+            self.adapter_params = adapter_params
 
         @classmethod
         def validate_profiling_config(cls, profiling_config):
@@ -405,6 +405,7 @@ def test_benchmark_runner_integration(temp_output_dir):
         "benchmark": bench_key,
         "benchmark_params": {},
         "adapter": "dummy_adapter",
+        "adapter_params": {},
         "profiling": {},
         "output_dir": temp_output_dir,  # injected temp dir for the test
         "report": {"analysis": {"enabled": True}},


### PR DESCRIPTION
This PR introduces support for adapter-specific configuration parameters by restructuring how adapter and backend settings are defined and consumed.

The goal is to allow users to directly define adapter-specific runtime configurations (such as `no_modify` or `queued` arguments for the MQSS Qiskit adapter). This improves modularity and makes the configuration system more extensible for future adapters.

## Changes
- Introduced `adapter_params` as a unified top-level configuration section for adapter-specific settings
- Added `backend_params` for adapter-specific backend configuration
  - Supports `mqss_qiskit` and `qiskit_simulator` adapters
- Moved existing adapter fields (`backend`, `credentials`, `shots`) under `adapter_params`
- Refactored `BenchmarkRunner` and `DeviceAdapter` implementations to use the new structure
- Updated tests, examples, and README
- Limit adapter circuit printing to verbose mode for cleaner batch run logs

## Breaking Changes

This change introduces a breaking change in the configuration schema.

- Top-level fields `backend`, `credentials`, and `shots` have been removed
- These fields must now be defined under `adapter_params`

Example:

```yaml id="q9k3lx"
adapter_params:
  backend: ...
  backend_params:
    ...
  credentials: ...
  shots: ...
```

Closes #32
