### PR TITLE
Introduce BenchmarkPipeline abstraction for extensible workflow integration

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -28,7 +28,7 @@ This document explains how to propose and implement changes in a way that fits a
 ```bash
 pip install uv
 uv sync --all-extras --dev
-````
+```
 
 ## Branching & Workflow
 
@@ -81,7 +81,7 @@ To run tests with coverage locally:
 
 ```bash
 uv run pytest --cov=src --cov-report=term-missing
-````
+```
 
 Notes specific to this repo:
 

--- a/docs/development_guide/contributing.md
+++ b/docs/development_guide/contributing.md
@@ -28,7 +28,7 @@ This document explains how to propose and implement changes in a way that fits a
 ```bash
 pip install uv
 uv sync --all-extras --dev
-````
+```
 
 ## Branching & Workflow
 
@@ -81,7 +81,7 @@ To run tests with coverage locally:
 
 ```bash
 uv run pytest --cov=src --cov-report=term-missing
-````
+```
 
 Notes specific to this repo:
 

--- a/src/mqssbench/cli/formatting.py
+++ b/src/mqssbench/cli/formatting.py
@@ -1,18 +1,20 @@
 from __future__ import annotations
 from colorama import Fore, Style, init as colorama_init
 from typing import Iterable, List, Optional
-from mqssbench.framework.types import BenchmarkResult, ExecutionResult
+from mqssbench.framework.types import PipelineResult, ExecutionResult
 
 # needed for Windows
 colorama_init(autoreset=True)
 
-def format_benchmark_result(result: BenchmarkResult) -> str:
-    """Return a clean, colored, human readable string for BenchmarkResult."""
+def format_benchmark_result(result: PipelineResult) -> str:
+    """Return a clean, colored, human readable string for PipelineResult."""
     parts = []
 
     # header
     parts.append(f"{Fore.CYAN}{Style.BRIGHT}Run ID: {Style.RESET_ALL}{result.run_id}")
     parts.append(f"{Fore.CYAN}{Style.BRIGHT}Benchmark: {Style.RESET_ALL}{result.benchmark_key}")
+    parts.append(f"{Fore.CYAN}{Style.BRIGHT}Category: {Style.RESET_ALL}{result.category}")
+    parts.append(f"{Fore.CYAN}{Style.BRIGHT}Status: {Style.RESET_ALL}{result.status}")
 
     # parameters
     if result.params:

--- a/src/mqssbench/framework/__init__.py
+++ b/src/mqssbench/framework/__init__.py
@@ -7,7 +7,8 @@ from .types import (
     RunContext,
     ExecutionResult,
     AnalysisResult,
-    BenchmarkResult,
+    PipelineResult,
+#    BenchmarkResult,
     ReportConfig,
 )
 from .circuit_generator import CircuitGenerator
@@ -17,6 +18,7 @@ from .benchmark_executor import (
     HybridBenchmarkExecutor,
 )
 from .benchmark_analyzer import BenchmarkAnalyzer, DefaultAnalyzer
+from .benchmark_pipeline import BenchmarkPipeline
 from .benchmark import Benchmark
 from .benchmark_registry import BenchmarkRegistry
 from .provider import CircuitProvider
@@ -31,7 +33,7 @@ __all__ = [
     "RunContext",
     "ExecutionResult",
     "AnalysisResult",
-    "BenchmarkResult",
+#    "BenchmarkResult",
     "ReportConfig",
     "CircuitGenerator",
     "BenchmarkExecutor",
@@ -39,6 +41,8 @@ __all__ = [
     "HybridBenchmarkExecutor",
     "BenchmarkAnalyzer",
     "DefaultAnalyzer",
+    "PipelineResult",
+    "BenchmarkPipeline",
     "Benchmark",
     "BenchmarkRegistry",
     "CircuitProvider",

--- a/src/mqssbench/framework/benchmark.py
+++ b/src/mqssbench/framework/benchmark.py
@@ -2,31 +2,30 @@
 
 from __future__ import annotations
 
-from abc import ABC, abstractmethod
+from abc import abstractmethod
 from typing import Any, Dict, Tuple, Type, TypeVar
 
 from .utils import validate_benchmark_registry_key
 
-from .types import BenchmarkCategory, RunContext, BenchmarkResult
+from .types import BenchmarkCategory, RunContext, PipelineResult, BenchmarkRunStatus
 from .circuit_generator import CircuitGenerator
 from .benchmark_executor import BenchmarkExecutor, HybridBenchmarkExecutor
 from .benchmark_analyzer import BenchmarkAnalyzer
+from .benchmark_pipeline import BenchmarkPipeline
 
 ComponentT = TypeVar(
     "ComponentT", CircuitGenerator, BenchmarkExecutor, BenchmarkAnalyzer
 )
 
 
-class Benchmark(ABC):
-    """Base class for all benchmarks.
+class Benchmark(BenchmarkPipeline):
+    """Abstract base class for generator/executor/analyzer benchmarks.
 
     Subclasses must define the following class-level attributes:
-    - ``origin``, ``source``, ``name``: used to build the benchmark registry key
-        with ``registry_key()`` (format: "origin/source/name").
     - ``generator``, ``executor``, ``analyzer``: classes used during ``run()``
         to generate circuits, execute them, and analyze results.
     - ``supported_adapters``: tuple of adapter names (empty tuple = no restriction).
-    - ``category``: a ``BenchmarkCategory`` instance describing the benchmark type.
+    - ``category``: a ``BenchmarkCategory`` instance describing the benchmark category.
 
     Implementations must override ``validate_params(self, params)`` to validate
     benchmark-specific parameters.
@@ -38,35 +37,26 @@ class Benchmark(ABC):
     and return a ``BenchmarkResult``.
 
     Helper methods:
-    - ``registry_key()``: returns the stable registry key string.
     - ``_instantiate_component()``: ensures a component is a class and a
         subclass of the expected type, then instantiates it with the current
         ``context``.
     - ``_validate_attributes()``: verifies all required class attributes and
         types at subclass definition time.
-    """
+    """   
 
     # Class-level attributes that must be defined by subclasses
-    origin: str
-    source: str
-    name: str
     generator: Type[CircuitGenerator]
     executor: Type[BenchmarkExecutor]
     analyzer: Type[BenchmarkAnalyzer]
     supported_adapters: Tuple[str, ...]  # Empty tuple means unrestricted
     category: BenchmarkCategory
 
-    def __init__(self, context: RunContext):
-        self.context = context
-
     def __init_subclass__(cls):
         super().__init_subclass__()
         cls._validate_attributes()
 
-    @classmethod
-    def registry_key(cls) -> str:
-        """Generate the registry key for this benchmark."""
-        return f"{cls.origin}/{cls.source}/{cls.name}"
+    def get_category(self) -> str:
+        return str(self.category)
 
     @abstractmethod
     def validate_params(self, params: Dict[str, Any]) -> None:
@@ -86,8 +76,8 @@ class Benchmark(ABC):
         """Validate the run context."""
         ...
 
-    def run(self) -> BenchmarkResult:
-        """Execute the benchmark."""
+    def run(self) -> PipelineResult:
+        """Run the benchmark pipeline."""
         self.validate_params(self.context.params)
         self.validate_adapter(self.context.adapter.name)
         self.validate_context(self.context)
@@ -98,20 +88,22 @@ class Benchmark(ABC):
         executor = self._instantiate_component(self.executor, BenchmarkExecutor)
 
         if isinstance(executor, HybridBenchmarkExecutor):
-            excecution_results = executor.run(generator, self.context)
+            execution_results = executor.run(generator, self.context)
         else:
-            excecution_results = executor.run(circuits, self.context)
+            execution_results = executor.run(circuits, self.context)
 
         analysis_result = None
         if self.context.report_config.analysis.enabled:
             analyzer = self._instantiate_component(self.analyzer, BenchmarkAnalyzer)
-            analysis_result = analyzer.analyze(excecution_results, self.context)
+            analysis_result = analyzer.analyze(execution_results, self.context)
 
-        return BenchmarkResult(
+        return PipelineResult(
             run_id=self.context.run_id,
             benchmark_key=self.context.benchmark_key,
+            category=self.get_category(),
+            status=BenchmarkRunStatus.COMPLETED,
             params=self.context.params,
-            execution_results=excecution_results,
+            execution_results=execution_results,
             analysis_result=analysis_result,
         )
 

--- a/src/mqssbench/framework/benchmark_pipeline.py
+++ b/src/mqssbench/framework/benchmark_pipeline.py
@@ -1,0 +1,43 @@
+"""Root pipeline abstraction for benchmark execution."""
+
+from __future__ import annotations
+
+from abc import ABC, abstractmethod
+
+from .types import PipelineResult, RunContext
+
+
+class BenchmarkPipeline(ABC):
+    """Abstract base class for all benchmark pipelines.
+    
+    Subclasses must define the following class-level attributes:
+    - ``origin``, ``source``, ``name``: used to build the benchmark registry key
+        with ``registry_key()`` (format: "origin/source/name").
+    - ``get_category``: a method that returns a category label for the benchmark.
+    - ``run``: a method that executes the benchmark pipeline and returns a ``PipelineResult``.
+
+    helpful methods:
+    - ``registry_key()``: returns the stable registry key string.
+    """
+
+    origin: str
+    source: str
+    name: str
+
+    def __init__(self, context: RunContext):
+        self.context = context
+
+    @classmethod
+    def registry_key(cls) -> str:
+        """Registry key in origin/source/name format."""
+        return f"{cls.origin}/{cls.source}/{cls.name}"
+
+    @abstractmethod
+    def run(self) -> PipelineResult:
+        """Run the pipeline and return a structured result."""
+        ...
+
+    @abstractmethod
+    def get_category(self) -> str:
+        """Return a category label for this pipeline."""
+        ...

--- a/src/mqssbench/framework/benchmark_registry.py
+++ b/src/mqssbench/framework/benchmark_registry.py
@@ -7,16 +7,16 @@ from typing import Dict, List, Optional, Type
 
 from .utils import validate_benchmark_registry_key
 
-from .benchmark import Benchmark
+from .benchmark_pipeline import BenchmarkPipeline
 from .types import RunContext, VALID_ORIGINS
 
 
 class BenchmarkRegistry:
-    """Registry for managing benchmark classes."""
+    """Registry for managing benchmark pipeline classes."""
 
     _instance: Optional[BenchmarkRegistry] = None
     _lock = threading.RLock() # for thread safety
-    _registry: Dict[str, Type[Benchmark]] = {}
+    _registry: Dict[str, Type[BenchmarkPipeline]] = {}
 
     def __new__(cls) -> BenchmarkRegistry:
         if cls._instance is None:
@@ -32,11 +32,11 @@ class BenchmarkRegistry:
         """Validate that the identifier follows the origin/source/name format."""
         validate_benchmark_registry_key(identifier)
 
-    def _register(self, benchmark_cls: Type[Benchmark]) -> Type[Benchmark]:
-        """Register a benchmark class in the registry."""
-        if not issubclass(benchmark_cls, Benchmark):
-            raise TypeError("Only Benchmark subclasses can be registered.")
-        key = benchmark_cls.registry_key()
+    def _register(self, pipeline_cls: Type[BenchmarkPipeline]) -> Type[BenchmarkPipeline]:
+        """Register a benchmark pipeline class in the registry."""
+        if not issubclass(pipeline_cls, BenchmarkPipeline):
+            raise TypeError("Only BenchmarkPipeline subclasses can be registered.")
+        key = pipeline_cls.registry_key()
         self._validate_key(key)
 
         with self._lock:
@@ -44,13 +44,13 @@ class BenchmarkRegistry:
                 raise ValueError(f"Benchmark '{key}' already registered.")
             # copy-on-write for safe lookups during writes
             new_map = dict(self._registry)
-            new_map[key] = benchmark_cls
+            new_map[key] = pipeline_cls
             self._registry = new_map
 
-        return benchmark_cls
+        return pipeline_cls
 
-    def _get(self, identifier: str) -> Type[Benchmark]:
-        """Get a registered benchmark class by its identifier."""
+    def _get(self, identifier: str) -> Type[BenchmarkPipeline]:
+        """Get a registered benchmark pipeline class by its identifier."""
         self._validate_key(identifier)
         try:
             return self._registry[identifier]
@@ -59,10 +59,10 @@ class BenchmarkRegistry:
                 f"Benchmark '{identifier}' is not registered."
             )
 
-    def _instantiate(self, identifier: str, context: RunContext) -> Benchmark:
-        """Instantiate a benchmark by its identifier with the given context."""
-        benchmark_cls = self._get(identifier)
-        return benchmark_cls(context)
+    def _instantiate(self, identifier: str, context: RunContext) -> BenchmarkPipeline:
+        """Instantiate a benchmark pipeline by its identifier with the given context."""
+        pipeline_cls = self._get(identifier)
+        return pipeline_cls(context)
 
     def _list_all(self) -> List[str]:
         """List all registered benchmark identifiers."""
@@ -85,9 +85,9 @@ class BenchmarkRegistry:
     # Public API
 
     @classmethod
-    def register_benchmark(cls, benchmark_cls: Type[Benchmark]) -> Type[Benchmark]:
+    def register_benchmark(cls, pipeline_cls: Type[BenchmarkPipeline]) -> Type[BenchmarkPipeline]:
         """
-        Decorator to register a Benchmark subclass with the BenchmarkRegistry.
+        Decorator to register a BenchmarkPipeline subclass with the BenchmarkRegistry.
 
         Example usage:
             @BenchmarkRegistry.register_benchmark
@@ -96,23 +96,22 @@ class BenchmarkRegistry:
                 source = "my_lib"
                 name = "my_benchmark"
         """
-        return cls()._register(benchmark_cls)
+        return cls()._register(pipeline_cls)
 
     @classmethod
-    def get_benchmark_class(cls, identifier: str) -> Type[Benchmark]:
-        """Get a registered benchmark class by identifier (added class method for convenience)."""
+    def get_benchmark_class(cls, identifier: str) -> Type[BenchmarkPipeline]:
+        """Get a registered benchmark pipeline class by identifier."""
         return cls()._get(identifier)
 
     @classmethod
-    def get_benchmark_instance(cls, identifier: str, context: RunContext) -> Benchmark:
-        """Instantiate a benchmark by identifier (added class method for convenience)."""
+    def get_benchmark_instance(cls, identifier: str, context: RunContext) -> BenchmarkPipeline:
+        """Instantiate a benchmark pipeline by identifier."""
         return cls()._instantiate(identifier, context)
 
     @classmethod
     def list_benchmarks(cls, origin: Optional[str] = None) -> List[str]:
-        """List registered benchmarks, optionally filtered by origin (added class method for convenience)."""
+        """List registered benchmarks, optionally filtered by origin."""
         instance = cls()
         if origin is None:
             return instance._list_all()
         return instance._list_by_origin(origin)
-

--- a/src/mqssbench/framework/types.py
+++ b/src/mqssbench/framework/types.py
@@ -23,6 +23,13 @@ class BenchmarkCategory(StrEnum):
     ALGORITHM = auto()
     SIMULATOR = auto()
 
+class BenchmarkRunStatus(StrEnum):
+    """Run status classification for benchmarks."""
+
+    PENDING = auto()
+    RUNNING = auto()
+    COMPLETED = auto()
+    FAILED = auto()
 
 CircuitType = Any
 
@@ -160,12 +167,14 @@ class AnalysisResult:
 
 
 @dataclass(frozen=True)
-class BenchmarkResult:
-    """Final result from a benchmark run."""
+class PipelineResult:
+    """Result from executing a benchmark pipeline."""
 
     run_id: str
     benchmark_key: str
-    params: Dict[str, Any] = field(default_factory=dict)  # benchmark parameters
+    category: str
+    status: BenchmarkRunStatus
+    params: Dict[str, Any] = field(default_factory=dict)
     execution_results: list[ExecutionResult] = field(default_factory=list)
     analysis_result: Optional[AnalysisResult] = None
     metadata: Dict[str, Any] = field(default_factory=dict)

--- a/src/mqssbench/library/__init__.py
+++ b/src/mqssbench/library/__init__.py
@@ -1,8 +1,8 @@
 """Library module containing concrete benchmark, adapter, and provider implementations."""
 
-from .loader import auto_import_builtin_library
+from .loader import load_plugins
 
 # Automatically register all builtin library modules
-auto_import_builtin_library()
+load_plugins()
 
 __all__ = []  

--- a/src/mqssbench/library/loader.py
+++ b/src/mqssbench/library/loader.py
@@ -8,6 +8,7 @@ ALLOWED_ROOT_PACKAGES = {
     "mqssbench.library.providers",
     "mqssbench.library.adapters",
     "mqssbench.library.benchmarks",
+    "mqssbench.library.pipelines",
 }
 
 MAX_DEPTH = 3  # to prevent excessively deep recursion
@@ -40,11 +41,15 @@ def _load_submodules(pkg, depth=0):
             _load_submodules(sub_pkg, depth + 1)
 
 
-def auto_import_builtin_library():
-    from . import providers, adapters, benchmarks
-    for pkg in (providers, adapters, benchmarks):
+def load_builtin_library():
+    from . import providers, adapters, benchmarks, pipelines
+    for pkg in (providers, adapters, benchmarks, pipelines):
         _load_submodules(pkg)
-    logger.info("Auto import of builtin library completed")
+    logger.info("Loading of builtin library completed")
 
+
+def load_plugins():
+    load_builtin_library()
+    
 
 # TODO: later add loading external plugins and plugin manager

--- a/src/mqssbench/library/pipelines/__init__.py
+++ b/src/mqssbench/library/pipelines/__init__.py
@@ -1,0 +1,1 @@
+"""Built-in benchmark pipeline plugins."""

--- a/src/mqssbench/runtime/benchmark_manager.py
+++ b/src/mqssbench/runtime/benchmark_manager.py
@@ -5,7 +5,7 @@ from ..framework import BenchmarkRegistry
 from ..framework import ProviderRegistry
 from ..framework import AdapterRegistry
 from .benchmark_runner import BenchmarkRunner
-from ..framework.types import BenchmarkResult
+from ..framework.types import PipelineResult
 
 
 class BenchmarkManager:
@@ -41,9 +41,9 @@ class BenchmarkManager:
         # implement validation logic (with pydantic, jsonschema or similar)
         return
 
-    def dispatch(self) -> List[BenchmarkResult]:
+    def dispatch(self) -> List[PipelineResult]:
         """
-        Run one or more benchmarks and return a list of BenchmarkResult objects.
+        Run one or more benchmarks and return a list of PipelineResult objects.
         """
         self._validate_config()
 
@@ -56,7 +56,7 @@ class BenchmarkManager:
         else:
             bench_list = [self.config]
 
-        results: List[BenchmarkResult] = []
+        results: List[PipelineResult] = []
         for conf in bench_list:
             if not isinstance(conf, dict):
                 raise TypeError("Each benchmark config must be a dict")

--- a/src/mqssbench/runtime/benchmark_runner.py
+++ b/src/mqssbench/runtime/benchmark_runner.py
@@ -5,7 +5,7 @@ from datetime import datetime
 import dataclasses
 from ..framework import AdapterRegistry
 from ..framework import RunContext, BenchmarkRegistry
-from ..framework.types import ProfilingConfig, BenchmarkResult, ReportConfig, StorageConfig
+from ..framework.types import ProfilingConfig, PipelineResult, ReportConfig, StorageConfig
 from ..framework.utils import show_artifacts
 from dacite import from_dict, Config
 from ..storage.storage_registry import get_storage
@@ -13,7 +13,7 @@ class BenchmarkRunner:
     def __init__(self, config: Dict[str, Any]):
         self.config = config
 
-    def run(self) -> BenchmarkResult:
+    def run(self) -> PipelineResult:
         # determine run directory
         output_dir = self.config.get("output_dir")
         if not output_dir:
@@ -56,21 +56,26 @@ class BenchmarkRunner:
             report_config=report_config_obj,
             profiling=profiling_config_obj,
         )
-        # get benchmark instance and run
-        benchmark = BenchmarkRegistry.get_benchmark_instance(benchmark_key, context)
-        benchmark_result = benchmark.run()
+        pipeline = BenchmarkRegistry.get_benchmark_instance(benchmark_key, context)
+        pipeline_result = pipeline.run()
 
         # get storage config and store result
         if storage_config_obj.enabled:
-            saved_location = self._store_result(context, storage_config_obj, benchmark_result)
+            saved_location = self._store_result(context, storage_config_obj, pipeline_result)
             if saved_location is not None:
-                benchmark_result = dataclasses.replace(benchmark_result, storage_location=saved_location)
+                pipeline_result = dataclasses.replace(
+                    pipeline_result, storage_location=saved_location
+                )
 
         # show plots if configured
-        if report_config_obj.analysis.visualization.enabled and report_config_obj.analysis.visualization.show:
-            show_artifacts(benchmark_result.analysis_result.artifacts.values())
-            
-        return benchmark_result
+        if (
+            pipeline_result.analysis_result is not None
+            and report_config_obj.analysis.visualization.enabled
+            and report_config_obj.analysis.visualization.show
+        ):
+            show_artifacts(pipeline_result.analysis_result.artifacts.values())
+
+        return pipeline_result
 
 
     def _resolve_benchmark_key(self) -> str:
@@ -88,14 +93,14 @@ class BenchmarkRunner:
         return f"{origin}/{source}/{name}"
 
 
-    def _store_result(self, context: RunContext, storage_config_obj: StorageConfig, benchmark_result: BenchmarkResult) -> Optional[str]:
+    def _store_result(self, context: RunContext, storage_config_obj: StorageConfig, pipeline_result: PipelineResult) -> Optional[str]:
         if not storage_config_obj.enabled:
             return None
         storage_backend = None
         saved_location: Optional[str] = None
         try:
             storage_backend = get_storage(storage_config_obj.type, context=context, config=storage_config_obj)
-            saved_location = storage_backend.save_result(benchmark_result)
+            saved_location = storage_backend.save_result(pipeline_result)
         finally:
             if storage_backend is not None:
                 try:

--- a/src/mqssbench/storage/file_storage.py
+++ b/src/mqssbench/storage/file_storage.py
@@ -1,7 +1,7 @@
 import json
 from datetime import datetime
 from pathlib import Path
-from ..framework.types import BenchmarkResult, RunContext
+from ..framework.types import PipelineResult, RunContext
 from .storage_registry import register_storage
 from .storage_backend import StorageBackend, StorageError
 from ..framework.utils import atomic_write
@@ -13,7 +13,7 @@ class FileStorage(StorageBackend):
         self.results_path = Path(self.context.run_dir) / "results.json"
         self.results_path.parent.mkdir(parents=True, exist_ok=True)
 
-    def save_result(self, result: BenchmarkResult) -> str:
+    def save_result(self, result: PipelineResult) -> str:
         try:
             if self.config.file.format != "json":
                 raise StorageError(f"Unsupported format: {self.config.file.format}")
@@ -33,7 +33,7 @@ class FileStorage(StorageBackend):
         return None
 
 
-def serialize_result_json(context: RunContext, result: BenchmarkResult) -> dict:
+def serialize_result_json(context: RunContext, result: PipelineResult) -> dict:
     now = datetime.utcnow().isoformat() + "Z"
 
     return {
@@ -41,6 +41,8 @@ def serialize_result_json(context: RunContext, result: BenchmarkResult) -> dict:
         "timestamp_utc": now,
         "run_id": context.run_id,
         "benchmark_key": result.benchmark_key,
+        "category": result.category,
+        "status": result.status,
         "benchmark_params": result.params,
         "adapter": {"backend": context.adapter.get_backend_name()},
         "execution_results": [

--- a/src/mqssbench/storage/storage_backend.py
+++ b/src/mqssbench/storage/storage_backend.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 from abc import ABC, abstractmethod
-from mqssbench.framework.types import BenchmarkResult, RunContext, StorageConfig
+from mqssbench.framework.types import PipelineResult, RunContext, StorageConfig
 
 class StorageError(Exception):
     pass
@@ -18,7 +18,7 @@ class StorageBackend(ABC):
         pass
 
     @abstractmethod
-    def save_result(self, result: BenchmarkResult) -> str:
+    def save_result(self, result: PipelineResult) -> str:
         """
         Persist the structured result (and return the path or URI to file, DB, etc.).
         Must be atomic: either succeed fully or raise StorageError.

--- a/test/framework/test_benchmark_registry.py
+++ b/test/framework/test_benchmark_registry.py
@@ -24,6 +24,7 @@ from mqssbench.framework.types import (
     CircuitSpec,
     BenchmarkCategory,
     AnalysisConfig,
+    BenchmarkRunStatus,
 )
 
 
@@ -180,13 +181,13 @@ def test_list_by_origin_invalid_origin_raises_value_error():
         BenchmarkRegistry.list_benchmarks(origin="not_a_valid_origin")
 
 
-def test_register_non_benchmark_class_raises_type_error():
-    """Passing a class that is not a Benchmark subclass to the decorator should raise TypeError."""
-    class NotABenchmark:
+def test_register_non_pipeline_class_raises_type_error():
+    """Passing a class that is not a BenchmarkPipeline subclass should raise TypeError."""
+    class NotAPipeline:
         pass
 
     with pytest.raises(TypeError):
-        BenchmarkRegistry.register_benchmark(NotABenchmark)
+        BenchmarkRegistry.register_benchmark(NotAPipeline)
 
 
 def test_invalid_benchmark_definition_raises_on_subclassing():
@@ -319,6 +320,7 @@ def test_end_to_end_benchmark_run_via_registry():
 
     assert result is not None
     assert result.benchmark_key == key
+    assert result.status == BenchmarkRunStatus.COMPLETED
     assert isinstance(result.execution_results, list)
     assert len(result.execution_results) == 1
 
@@ -427,6 +429,7 @@ def test_benchmark_runner_integration(temp_output_dir):
     assert ex.counts["1"] == 3
     assert result.analysis_result is not None
     assert result.analysis_result.metrics["total_shots"] == 5
+    assert result.status == BenchmarkRunStatus.COMPLETED
 
 
 # -----------------------------------------------------------------------------


### PR DESCRIPTION
This PR introduces a `BenchmarkPipeline` abstraction to extend MBF beyond the existing `Benchmark` execution model and enable support for custom workflow implementations and external framework integrations.

### Changes

- Establish foundation for custom workflow implementations and external framework integrations
- Add `BenchmarkPipeline` base interface to generalize execution beyond standard `Benchmark` workflows
- Refactor `Benchmark` abstraction to support extensible pipeline-based execution
- Enable external frameworks to integrate via unified registry mechanism
- Update registry, runtime layer, storage, CLI, and tests to support pipeline execution model
- Add benchmark run status tracking for pipeline execution lifecycle
- Fix minor typo in `CONTRIBUTING.md`

Closes #49 