### PR TITLE
Fix PennyLane adapter result handling and add smoke test suite

### DIFF
--- a/examples/smoke/README.md
+++ b/examples/smoke/README.md
@@ -1,0 +1,27 @@
+# Smoke checks
+
+Minimal manual checks to verify device adapters work end-to-end. These are not production benchmarks.
+
+## Run
+
+From the repo root:
+
+```bash
+# all smoke tests
+uv run python examples/smoke/run.py
+
+# one test
+uv run python examples/smoke/run.py mqss_pennylane_bell
+uv run python examples/smoke/run.py mqss_qiskit_bell
+```
+
+Set `MQSS_TOKEN` or fill in `credentials.mqss_token` inside each smoke file before running against a real backend.
+
+## Add a new smoke test
+
+Add a new `*.py` file in this folder with:
+
+1. a benchmark registered under `user/smoke/...`
+2. a `SMOKE_CONFIG` dict at the bottom
+
+`run.py` picks it up automatically, no changes needed there.

--- a/examples/smoke/mqss_pennylane_bell.py
+++ b/examples/smoke/mqss_pennylane_bell.py
@@ -1,0 +1,76 @@
+"""Minimal Bell-state benchmark for manual PennyLane adapter smoke checks."""
+
+from typing import Any, Dict, List, Tuple, override
+
+import pennylane as qml
+
+from mqssbench.framework import (
+    Benchmark,
+    BenchmarkCategory,
+    BenchmarkRegistry,
+    CircuitGenerator,
+    CircuitSpec,
+    DefaultAnalyzer,
+    DefaultBenchmarkExecutor,
+)
+
+
+class BellStateGenerator(CircuitGenerator):
+    @override
+    def generate(self, params: Dict[str, Any]) -> List[CircuitSpec]:
+        def build(device):
+            @qml.qnode(device)
+            def circuit():
+                qml.Hadamard(wires=0)
+                qml.CNOT(wires=[0, 1])
+                return qml.counts(wires=[0, 1])
+
+            return circuit
+
+        return [CircuitSpec(circuit=build, metadata={"num_qubits": 2})]
+
+
+@BenchmarkRegistry.register_benchmark
+class PennyLaneBellBenchmark(Benchmark):
+    origin = "user"
+    source = "smoke"
+    name = "pennylane_bell"
+
+    generator = BellStateGenerator
+    executor = DefaultBenchmarkExecutor
+    analyzer = DefaultAnalyzer
+
+    supported_adapters: Tuple[str, ...] = ("mqss_pennylane",)
+    category = BenchmarkCategory.SOFTWARE
+
+    @override
+    def validate_params(self, params: Dict[str, Any]) -> None:
+        pass
+
+
+SMOKE_CONFIG = {
+    "benchmark": PennyLaneBellBenchmark.registry_key(),
+    "benchmark_params": {},
+    "adapter": "mqss_pennylane",
+    "adapter_params": {
+        "backend": "QExa20",
+        "backend_params": {},
+        "credentials": {"mqss_token": ""},
+        "shots": 200,
+    },
+    "output_dir": "./results",
+    "report": {
+        "analysis": {
+            "enabled": True,
+            "visualization": {
+                "enabled": False,
+                "show": False,
+            },
+        },
+    },
+    "storage": {
+        "enabled": True,
+        "type": "file",
+        "file": {"format": "json"},
+    },
+}

--- a/examples/smoke/mqss_qiskit_bell.py
+++ b/examples/smoke/mqss_qiskit_bell.py
@@ -1,0 +1,72 @@
+"""Minimal Bell-state benchmark for manual Qiskit adapter smoke checks."""
+
+from typing import Any, Dict, List, Tuple, override
+
+from qiskit import QuantumCircuit
+
+from mqssbench.framework import (
+    Benchmark,
+    BenchmarkCategory,
+    BenchmarkRegistry,
+    CircuitGenerator,
+    CircuitSpec,
+    DefaultAnalyzer,
+    DefaultBenchmarkExecutor,
+)
+
+
+class BellStateGenerator(CircuitGenerator):
+    @override
+    def generate(self, params: Dict[str, Any]) -> List[CircuitSpec]:
+        qc = QuantumCircuit(2, 2)
+        qc.h(0)
+        qc.cx(0, 1)
+        qc.measure([0, 1], [0, 1])
+
+        return [CircuitSpec(circuit=qc, metadata={"num_qubits": 2})]
+
+
+@BenchmarkRegistry.register_benchmark
+class QiskitBellBenchmark(Benchmark):
+    origin = "user"
+    source = "smoke"
+    name = "qiskit_bell"
+
+    generator = BellStateGenerator
+    executor = DefaultBenchmarkExecutor
+    analyzer = DefaultAnalyzer
+
+    supported_adapters: Tuple[str, ...] = ("mqss_qiskit",)
+    category = BenchmarkCategory.SOFTWARE
+
+    @override
+    def validate_params(self, params: Dict[str, Any]) -> None:
+        pass
+
+
+SMOKE_CONFIG = {
+    "benchmark": QiskitBellBenchmark.registry_key(),
+    "benchmark_params": {},
+    "adapter": "mqss_qiskit",
+    "adapter_params": {
+        "backend": "QExa20",
+        "backend_params": {},
+        "credentials": {"mqss_token": ""},
+        "shots": 200,
+    },
+    "output_dir": "./results",
+    "report": {
+        "analysis": {
+            "enabled": True,
+            "visualization": {
+                "enabled": False,
+                "show": False,
+            },
+        },
+    },
+    "storage": {
+        "enabled": True,
+        "type": "file",
+        "file": {"format": "json"},
+    },
+}

--- a/examples/smoke/run.py
+++ b/examples/smoke/run.py
@@ -1,0 +1,88 @@
+"""Run smoke benchmarks, especially for making sure the device adapter works as expected."""
+
+from __future__ import annotations
+
+import argparse
+import importlib
+import sys
+from pathlib import Path
+from types import ModuleType
+
+from mqssbench.cli.formatting import format_benchmark_result
+from mqssbench.runtime.benchmark_manager import BenchmarkManager
+
+SMOKE_DIR = Path(__file__).resolve().parent
+SKIP_MODULES = frozenset({"run"})
+
+
+def discover_smoke_modules() -> list[str]:
+    return sorted(
+        path.stem
+        for path in SMOKE_DIR.glob("*.py")
+        if path.stem not in SKIP_MODULES and not path.stem.startswith("_")
+    )
+
+
+def load_smoke_modules(selected: list[str] | None = None) -> list[ModuleType]:
+    if str(SMOKE_DIR) not in sys.path:
+        sys.path.insert(0, str(SMOKE_DIR))
+
+    available = discover_smoke_modules()
+    if selected:
+        unknown = sorted(set(selected) - set(available))
+        if unknown:
+            raise SystemExit(
+                f"Unknown smoke test(s): {', '.join(unknown)}. "
+                f"Available: {', '.join(available)}"
+            )
+        module_names = selected
+    else:
+        module_names = available
+
+    return [importlib.import_module(name) for name in module_names]
+
+
+def collect_smoke_configs(modules: list[ModuleType]) -> list[dict]:
+    configs: list[dict] = []
+    for module in modules:
+        config = getattr(module, "SMOKE_CONFIG", None)
+        if config is None:
+            continue
+        if not isinstance(config, dict):
+            raise TypeError(f"{module.__name__}.SMOKE_CONFIG must be a dict")
+        configs.append(config)
+    return configs
+
+
+def main() -> None:
+    available = discover_smoke_modules()
+    parser = argparse.ArgumentParser(description="Run mqssbench smoke checks")
+    parser.add_argument(
+        "tests",
+        nargs="*",
+        metavar="TEST",
+        help=(
+            "Smoke module(s) to run, e.g. mqss_pennylane_bell mqss_qiskit_bell. "
+            f"Default: all ({', '.join(available) or 'none found'})"
+        ),
+    )
+    args = parser.parse_args()
+
+    selected = args.tests or None
+    modules = load_smoke_modules(selected)
+    configs = collect_smoke_configs(modules)
+
+    if not configs:
+        raise SystemExit("No smoke configs found. Each smoke module needs SMOKE_CONFIG.")
+
+    results = []
+    for config in configs:
+        results.extend(BenchmarkManager(config).dispatch())
+
+    for result in results:
+        print(format_benchmark_result(result))
+        print()
+
+
+if __name__ == "__main__":
+    main()

--- a/src/mqssbench/library/adapters/mqss/pennylane_adapter.py
+++ b/src/mqssbench/library/adapters/mqss/pennylane_adapter.py
@@ -1,7 +1,6 @@
 import logging
-from typing import override, Callable, cast
+from typing import override
 from mqss.pennylane_adapter.device import MQSSPennylaneDevice
-from pennylane import QNode
 from ....framework.adapter import DeviceAdapter
 from ....framework.adapter_registry import AdapterRegistry
 from .config import MQSS_TOKEN, MQSS_BACKEND, MQSS_VALID_PROFILING_METRICS

--- a/src/mqssbench/library/adapters/mqss/pennylane_adapter.py
+++ b/src/mqssbench/library/adapters/mqss/pennylane_adapter.py
@@ -88,6 +88,9 @@ class PennyLaneAdapter(DeviceAdapter):
         if num_qubits is None:
             raise ValueError("num_qubits must be provided to create PennyLane device")
         
+        if not callable(circuit):
+            raise ValueError("circuit must be a callable function")
+
         device = self._get_device(num_qubits)
 
         # TODO: for now implement transpile_mode, later consider exploring alternatives to transpilation here
@@ -95,15 +98,22 @@ class PennyLaneAdapter(DeviceAdapter):
         print(f"Running circuit on backend {self._backend_name} ...")
         logger.info("circuit\n%s", circuit)
 
-        # Build qnode
-        if callable(circuit):
-            # cast circuit so pyright knows it's callable and returns QNode
-            circuit = cast(Callable[..., QNode], circuit)
-            qnode = circuit(device)
-        else:
-            qnode = circuit
+        result = None
 
-        job_result_count = qnode()
+        try:
+            result_obj = circuit(device)
+        except TypeError:
+            result_obj = circuit()
+
+        if callable(result_obj):
+            result = result_obj()
+        else:
+            result = result_obj
+
+        job_result_count = {}
+        if isinstance(result, dict):
+            job_result_count = result
+
         # TODO: implement storing job id in pennylane
         if MQSS_PENNYLANE_PROFILING_ENABLED:
             # To be implemented: get profiling data from job_profiler_metrics


### PR DESCRIPTION
This PR fixes an issue with the PennyLane adapter result handling and introduces a new smoke test suite to facilitate the verification of device adapters.

### Changes:
- Fixed PennyLane adapter result handling issue
- Added smoke test suites in `examples/smoke/` folder containing basic run verification scripts
- Included MQSS Qiskit and MQSS PennyLane Bell state smoke test examples
- Added a minimal README for the smoke tests including usage instructions

closes #47 